### PR TITLE
correction on lang_DE: ordnum, plural and ord form of >= 10**6

### DIFF
--- a/num2words/base.py
+++ b/num2words/base.py
@@ -101,7 +101,6 @@ class Num2Word_Base(object):
 
         if value >= self.MAXVAL:
             raise OverflowError(self.errmsg_toobig % (value, self.MAXVAL))
-        
 
         val = self.splitnum(value)
         words, num = self.clean(val)

--- a/num2words/lang_DE.py
+++ b/num2words/lang_DE.py
@@ -59,20 +59,19 @@ class Num2Word_DE(Num2Word_EU):
                      "nen": "nens",
                      "rde": "rdes",
                      "rden": "rdens"}
-        self.ordflag = False
 
     def merge(self, curr, next):
         ctext, cnum, ntext, nnum = curr + next
 
         if cnum == 1:
-            if nnum < 10**6 or self.ordflag:
+            if nnum < 10**6:
                 return next
             ctext = "eine"
 
         if nnum > cnum:
             if nnum >= 10**6:
                 if cnum > 1:
-                    if ntext.endswith("e") or self.ordflag:
+                    if ntext.endswith("e"):
                         ntext += "n"
                     else:
                         ntext += "en"

--- a/num2words/lang_DE.py
+++ b/num2words/lang_DE.py
@@ -26,7 +26,6 @@ class Num2Word_DE(Num2Word_EU):
             self.cards[10**n] = word + "illiarde"
             self.cards[10**(n-3)] = word + "illion"
 
-
     def setup(self):
         self.negword = "minus "
         self.pointword = "Komma"
@@ -49,13 +48,18 @@ class Num2Word_DE(Num2Word_EU):
                              "zw\xF6lf", "elf", "zehn", "neun", "acht", "sieben",
                              "sechs", "f\xFCnf", "vier", "drei", "zwei", "eins",
                              "null"]
-        self.ords = { "eins"    : "ers",
-                      "drei"    : "drit",
-                      "acht"    : "ach",
-                      "sieben"  : "sieb",
-                      "ig"      : "igs" }
+        self.ords = {"eins": "ers",
+                     "drei": "drit",
+                     "acht": "ach",
+                     "sieben": "sieb",
+                     "ig": "igs",
+                     "ert": "erts",
+                     "end": "ends",
+                     "ion": "ions",
+                     "nen": "nens",
+                     "rde": "rdes",
+                     "rden": "rdens"}
         self.ordflag = False
-
 
     def merge(self, curr, next):
         ctext, cnum, ntext, nnum = curr + next
@@ -69,41 +73,35 @@ class Num2Word_DE(Num2Word_EU):
             if nnum >= 10**6:
                 if cnum > 1:
                     if ntext.endswith("e") or self.ordflag:
-                        ntext += "s"
+                        ntext += "n"
                     else:
-                        ntext += "es"
+                        ntext += "en"
                 ctext += " "
             val = cnum * nnum
         else:
             if nnum < 10 < cnum < 100:
                 if nnum == 1:
                     ntext = "ein"
-                ntext, ctext =  ctext, ntext + "und"
+                ntext, ctext = ctext, ntext + "und"
             elif cnum >= 10**6:
                 ctext += " "
             val = cnum + nnum
 
         word = ctext + ntext
         return (word, val)
-            
 
     def to_ordinal(self, value):
         self.verify_ordinal(value)
-        self.ordflag = True
         outword = self.to_cardinal(value)
-        self.ordflag = False
         for key in self.ords:
             if outword.endswith(key):
                 outword = outword[:len(outword) - len(key)] + self.ords[key]
                 break
         return outword + "te"
 
-
-    # Is this correct??
     def to_ordinal_num(self, value):
         self.verify_ordinal(value)
-        return str(value) + "te"
-
+        return str(value) + "."
 
     def to_currency(self, val, longval=True, old=False):
         if old:
@@ -117,8 +115,6 @@ class Num2Word_DE(Num2Word_EU):
             return self.to_cardinal(val)
         return self.to_splitnum(val, hightxt="hundert", longval=longval)
 
-
-            
 n2w = Num2Word_DE()
 to_card = n2w.to_cardinal
 to_ord = n2w.to_ordinal
@@ -126,15 +122,20 @@ to_ordnum = n2w.to_ordinal_num
 
 
 def main():
-    for val in [ 1, 11, 12, 21, 31, 33, 71, 80, 81, 91, 99, 100, 101, 102, 155,
+    for val in [1, 7, 8, 12, 17, 81, 91, 99, 100, 101, 102, 155,
              180, 300, 308, 832, 1000, 1001, 1061, 1100, 1500, 1701, 3000,
-             8280, 8291, 150000, 500000, 1000000, 2000000, 2000001,
+             8280, 8291, 150000, 500000, 3000000, 1000000, 2000001, 1000000000, 2000000000,
              -21212121211221211111, -2.121212, -1.0000100]:
         n2w.test(val)
 
-    n2w.test(1325325436067876801768700107601001012212132143210473207540327057320957032975032975093275093275093270957329057320975093272950730)
+    # n2w.test(1325325436067876801768700107601001012212132143210473207540327057320957032975032975093275093275093270957329057320975093272950730)
+    n2w.test(3000000)
+    n2w.test(3000000000001)
+    n2w.test(3000000324566)
     print n2w.to_currency(112121)
     print n2w.to_year(2000)
+    print n2w.to_year(1820)
+    print n2w.to_year(2001)
 
 if __name__ == "__main__":
     main()

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -1,0 +1,38 @@
+# -*- encoding: utf-8 -*-
+# Copyright (c) 2015, Savoir-faire Linux inc.  All Rights Reserved.
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301 USA
+
+from __future__ import unicode_literals
+
+from unittest import TestCase
+
+from num2words import num2words
+
+class Num2WordsDETest(TestCase):
+    def test_ordinal_less_than_twenty(self):
+        self.assertEqual(num2words(7, ordinal=True, lang='de'), "siebte")
+        self.assertEqual(num2words(8, ordinal=True, lang='de'), "achte")
+        self.assertEqual(num2words(12, ordinal=True, lang='de'), "zwölfte")
+        self.assertEqual(num2words(17, ordinal=True, lang='de'), "siebzehnte")
+
+    def test_ordinal_more_than_twenty(self):
+        self.assertEqual(num2words(81, ordinal=True, lang='de'), "einundachtzigste")
+
+    def test_ordinal_at_crucial_number(self):
+        self.assertEqual(num2words(100, ordinal=True, lang='de'), "hundertste")
+        self.assertEqual(num2words(1000, ordinal=True, lang='de'), "tausendste")
+        self.assertEqual(num2words(4000, ordinal=True, lang='de'), "viertausendste")
+        self.assertEqual(num2words(2000000, ordinal=True, lang='de'), "zwei millionenste")
+        self.assertEqual(num2words(5000000000, ordinal=True, lang='de'), "fünf milliardenste")

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -36,3 +36,16 @@ class Num2WordsDETest(TestCase):
         self.assertEqual(num2words(4000, ordinal=True, lang='de'), "viertausendste")
         self.assertEqual(num2words(2000000, ordinal=True, lang='de'), "zwei millionenste")
         self.assertEqual(num2words(5000000000, ordinal=True, lang='de'), "fünf milliardenste")
+
+    def test_cardinal_at_some_numbers(self):
+        self.assertEqual(num2words(2000000, lang='de'), "zwei millionen")
+        self.assertEqual(num2words(4000000000, lang='de'), "vier milliarden")
+
+    def test_cardinal_for_decimal_number(self):
+        self.assertEqual(num2words(3.486, lang='de'), "drei Komma vier acht")
+
+    def test_ordinal_for_negative_numbers(self):
+        self.assertRaises(TypeError, num2words, -12, ordinal=True, lang='de')
+
+    def test_ordinal_for_floating_numbers(self):
+        self.assertRaises(TypeError, num2words, 2.453, ordinal=True, lang='de')


### PR DESCRIPTION
I am not a German native. But I'm quite sure about the correction I've made.
1. using '.' instead of 'te' as suffix of ordinal number. ex: 23.
2. normally, German use 'en' instead of 'es' for the plural of 'million' so it becomes 'millionen'
3. Ordinal form of number 100, 1000 and so on, it adds 'ste' instead of only 'te'. example: hundertste, tausendste ...

However it needs to be verified.