### PR TITLE
TODO: Use German error messages [Done]

### DIFF
--- a/num2words/lang_DE.py
+++ b/num2words/lang_DE.py
@@ -17,7 +17,7 @@
 from __future__ import unicode_literals
 from .lang_EU import Num2Word_EU
 
-#//TODO: Use German error messages
+
 class Num2Word_DE(Num2Word_EU):
     def set_high_numwords(self, high):
         max = 3 + 6*len(high)
@@ -30,8 +30,8 @@ class Num2Word_DE(Num2Word_EU):
     def setup(self):
         self.negword = "minus "
         self.pointword = "Komma"
-        self.errmsg_nonnum = "Only numbers may be converted to words."
-        self.errmsg_toobig = "Number is too large to convert to words."
+        self.errmsg_nonnum = "Only numbers may be converted to words. - Nur Zahlen können ausgeschrieben werden."
+        self.errmsg_toobig = "Number is too large to convert to words. - Die Zahl kann nicht ausgeschrieben werden. Sie ist zu gro\xDF."
         self.exclude_title = []
 
         lows = ["non", "okt", "sept", "sext", "quint", "quadr", "tr", "b", "m"]


### PR DESCRIPTION
I removed the comment ("TODO: Use German error messages") and I added a translation for the two error messsages:

(1) Only numbers may be converted to words. - Nur Zahlen können ausgeschrieben werden.

(2) Number is too large to convert to words. - Die Zahl kann nicht ausgeschrieben werden. Sie ist zu groß.

I can't suggest to use German error messages only. Maybe not all users, wanting to write numbers in German, can read German error messages fluently. When I have time, I will have a look at the output of the code.