### PR TITLE
Improvements, corrections, and bug fixes for the `lang_IT` module.

### DIFF
--- a/num2words/lang_IT.py
+++ b/num2words/lang_IT.py
@@ -86,6 +86,9 @@ def omitt_if_zero(number_to_string):
 
 class Num2Word_IT(Num2Word_EU):
 
+    MINUS_PREFIX_WORD = "meno "
+    FLOAT_INFIX_WORD = " virgola "
+
     def __init__(self):
         pass
 
@@ -98,7 +101,7 @@ class Num2Word_IT(Num2Word_EU):
             # Drops the trailing zero and comma                     ~~~~
             [self.to_cardinal(int(c)) for c in str(float_number % 1)[2:]]
         )
-        return prefix + " virgola " + postfix
+        return prefix + Num2Word_IT.FLOAT_INFIX_WORD + postfix
 
     def tens_to_cardinal(self, number):
         tens = number // 10
@@ -161,7 +164,7 @@ class Num2Word_IT(Num2Word_EU):
 
     def to_cardinal(self, number):
         if number < 0:
-            string = "meno " + self.to_cardinal(-number)
+            string = Num2Word_IT.MINUS_PREFIX_WORD + self.to_cardinal(-number)
         elif number % 1 != 0:
             string = self.float_to_words(number)
         elif number < 20:
@@ -182,7 +185,7 @@ class Num2Word_IT(Num2Word_EU):
         #   centodecimo VS centodieciesimo VS centesimo decimo?
         is_outside_teens = not 10 < tens < 20
         if number < 0:
-            return "meno " + self.to_ordinal(-number)
+            return Num2Word_IT.MINUS_PREFIX_WORD + self.to_ordinal(-number)
         elif number % 1 != 0:
             return self.float_to_words(number, ordinal=True)
         elif number < 20:

--- a/num2words/lang_IT.py
+++ b/num2words/lang_IT.py
@@ -13,205 +13,135 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 # MA 02110-1301 USA
 
+# TODO: Implement commas for long numbers
+# TODO: Accents on "tre"
+
 from __future__ import unicode_literals
 from .lang_EU import Num2Word_EU
 
-import re
-import math
+ZERO = "zero"
 
-class Num2Word_IT(object):
+STR_0_to_19 = [
+    ZERO, "uno", "due", "tre", "quattro", "cinque", "sei", "sette", "otto",
+    "nove", "dieci", "undici", "dodici", "tredici", "quattordici", "quindici",
+    "sedici", "diciassette", "diciotto", "diciannove"
+]
+
+STR_TENS = {2: "venti", 3: "trenta", 4: "quaranta", 6: "sessanta"}
+
+# Utils
+# =====
+
+def as_number(digits):
+    return int("".join(map(str, digits)) or "0")
+
+def stringify_exponent(exponent):
+    mod = exponent % 6
+    prefix = {6: "m", 12: "b", 18: "tr", 24: "quadr"}[exponent - mod]
+    return prefix + ("ilione" if mod == 0 else "iliardo")
+
+def omitt_if_zero(number_to_string):
+    return "" if number_to_string == ZERO else number_to_string
+
+# Big numbers helpers
+# ===================
+
+def break_into_blocks(digits, length):
+    if length < 4:
+        return digits
+    elif length <= 30:
+        mod = length % 3 or 3
+        return [digits[:mod], digits[mod:]]
+    else:
+        mod = length % 27 # We use "quadriliardi" for very big numbers
+        return break_into_blocks(digits[:mod], mod) + digits[mod:]
+
+class Num2Word_IT(Num2Word_EU):
+
     def __init__(self):
-        self._minus = "meno "
-
-        self._exponent = {
-            0 : ('',''),
-            3 : ('mille','mila'),
-            6 : ('milione','miloni'),
-            12 : ('miliardo','miliardi'),
-            18 : ('trillone','trilloni'),
-            24 : ('quadrilione','quadrilioni')}
-
-        self._digits = ['zero', 'uno', 'due', 'tre', 'quattro', 'cinque', 'sei', 'sette', 'otto', 'nove']
-
-        self._sep = ''
-
-    def _toWords(self, num, power=0):
-        str_num = str(num)
-        # The return string;
-        ret = ''
-
-        # add a the word for the minus sign if necessary
-        if num < 0:
-            ret = self._sep + self._minus
-
-        if len(str_num) > 6:
-            current_power = 6
-            # check for highest power
-            if power in self._exponent:
-                # convert the number above the first 6 digits
-                # with it's corresponding $power.
-                snum = str_num[0:-6]
-                if snum != '':
-                    ret = ret + self._toWords(int(snum), power + 6)
-
-            num = int(str_num[-6:])
-            if num == 0:
-                return ret
-
-        elif num == 0 or str_num == '':
-            return ' ' + self._digits[0] + ' '
-        else:
-            current_power = len(str_num)
-
-        # See if we need "thousands"
-        thousands = math.floor(num / 1000)
-        if thousands == 1:
-            ret = ret + self._sep + 'mille' + self._sep
-        elif thousands > 1:
-            ret = ret + self._toWords(int(thousands), 3) + self._sep
-
-        # values for digits, tens and hundreds
-        h = int(math.floor((num / 100) % 10))
-        t = int(math.floor((num / 10) % 10))
-        d = int(math.floor(num % 10))
-
-        # centinaia: duecento, trecento, etc...
-        if h == 1:
-            if ((d==0) and (t == 0)):# is it's '100' use 'cien'
-                ret = ret + self._sep + 'cento'
-            else:
-                ret = ret + self._sep + 'cento'
-        elif h == 2 or h == 3 or h == 4 or h == 6 or h == 8:
-            ret = ret + self._sep + self._digits[h] + 'cento'
-        elif h == 5:
-            ret = ret + self._sep + 'cinquecento'
-        elif h == 7:
-            ret = ret + self._sep + 'settecento'
-        elif h == 9:
-            ret = ret + self._sep + 'novecento'
-
-        # decine: venti trenta, etc...
-        if t == 9:
-            if d == 1 or d == 8:
-                ret = ret + self._sep + 'novant'
-            else:
-                ret = ret + self._sep + 'novanta'
-        if t == 8:
-            if d == 1 or d == 8:
-                ret = ret + self._sep + 'ottant'
-            else:
-                ret = ret + self._sep + 'ottanta'
-        if t == 7:
-            if d == 1 or d == 8:
-                ret = ret + self._sep + 'settant'
-            else:
-                ret = ret + self._sep + 'settanta'
-        if t == 6:
-            if d == 1 or d == 8:
-                ret = ret + self._sep + 'sessant'
-            else:
-                ret = ret + self._sep + 'sessanta'
-        if t == 5:
-            if d == 1 or d == 8:
-                ret = ret + self._sep + 'cinquant'
-            else:
-                ret = ret + self._sep + 'cinquanta'
-        if t == 4:
-            if d == 1 or d == 8:
-                ret = ret + self._sep + 'quarant'
-            else:
-                ret = ret + self._sep + 'quaranta'
-        if t == 3:
-            if d == 1 or d == 8:
-                ret = ret + self._sep + 'trent'
-            else:
-                ret = ret + self._sep + 'trenta'
-        if t == 2:
-            if d == 0:
-                ret = ret + self._sep + 'venti'
-            elif (d == 1 or d == 8):
-                ret = ret + self._sep + 'vent' + self._digits[d]
-            else:
-                ret = ret + self._sep + 'venti' + self._digits[d]
-        if t == 1:
-            if d == 0:
-                ret = ret + self._sep + 'dieci'
-            elif d == 1:
-                ret = ret + self._sep + 'undici'
-            elif d == 2:
-                ret = ret + self._sep + 'dodici'
-            elif d == 3:
-                ret = ret + self._sep + 'tredici'
-            elif d == 4:
-                ret = ret + self._sep + 'quattordici'
-            elif d == 5:
-                ret = ret + self._sep + 'quindici'
-            elif d == 6:
-                ret = ret + self._sep + 'sedici'
-            elif d == 7:
-                ret = ret + self._sep + 'diciassette'
-            elif d == 8:
-                ret = ret + self._sep + 'diciotto'
-            elif d == 9:
-                ret = ret + self._sep + 'diciannove'
-
-        # add digits only if it is a multiple of 10 and not 1x or 2x
-        if t != 1 and t != 2 and d > 0:
-            # don't add 'e' for numbers below 10
-            if t != 0:
-                # use 'un' instead of 'uno' when there is a suffix ('mila', 'milloni', etc...)
-                if (power > 0) and ( d == 1):
-                    ret = ret + self._sep + 'e un'
-                else:
-                    ret = ret + self._sep + '' + self._digits[d]
-            else:
-                if power > 0 and d == 1:
-                    ret = ret + self._sep + 'un '
-                else:
-                    ret = ret + self._sep + self._digits[d]
-
-        if power > 0:
-            if power in self._exponent:
-                lev = self._exponent[power]
-
-            if lev is None:
-                return None
-
-            # if it's only one use the singular suffix
-            if d == 1 and t == 0 and h == 0:
-                suffix = lev[0]
-            else:
-                suffix = lev[1]
-
-            if num != 0:
-                ret = ret + self._sep + suffix
-
-        return ret
-
-
-    def to_cardinal(self, number):
-        return self._toWords(number)
-
-    def to_ordinal_num(self, number):
         pass
 
-    def to_ordinal(self,value):
-        if 0 <= value <= 10:
-            return ["primo", "secondo", "terzo", "quarto", "quinto", "sesto", "settimo", "ottavo", "nono", "decimo"][value - 1]
+    def float_to_cardinal(self, float_number):
+        decimal_part_as_int = int(str(float_number % 1)[1:])
+        whole_part_to_string = self.to_cardinal(int(float_number))
+        decimal_part_to_string = self.to_cardinal(decimal_part_as_int)
+        return whole_part_to_string + " virgola " + decimal_part_to_string
+
+    def two_digits_to_cardinal(self, number):
+        tens = number / 10
+        units = number % 10
+        if tens in STR_TENS:
+            tens_to_string = STR_TENS[tens]
         else:
-            as_word = self._toWords(value)
-            if as_word.endswith("dici"):
-                return re.sub("dici$", "dicesimo", as_word)
-            elif as_word.endswith("to"):
-                return re.sub("to$", "tesimo", as_word)
-            elif as_word.endswith("ta"):
-                return re.sub("ta$", "tesimo", as_word)
+            tens_to_string = STR_0_to_19[tens][:-1] + "anta"
+        if units in [1, 8]: # Ottant(a)otto, sessant(a)uno
+            tens_to_string = tens_to_string[:-1] # Drop last
+        units_to_string = omitt_if_zero(STR_0_to_19[units])
+        return tens_to_string + units_to_string
+
+    def hundreds_to_cardinal(self, number):
+        hundreds = number / 100
+        hundreds_to_string = "cento"
+        if hundreds != 1:
+            hundreds_to_string = STR_0_to_19[hundreds] + hundreds_to_string
+        remainder_to_string = omitt_if_zero(self.to_cardinal(number % 100))
+        return hundreds_to_string + remainder_to_string
+
+    def thousands_to_cardinal(self, number):
+        thousands = number / 1000
+        if thousands == 1:
+            thousands_to_string = "mille"
+        else:
+            thousands_to_string = self.to_cardinal(thousands) + "mila"
+        remainder_to_string = omitt_if_zero(self.to_cardinal(number % 1000))
+        return thousands_to_string + remainder_to_string
+
+    def big_exponent_to_cardinal(self, number):
+        digits = [int(c) for c in str(number)]
+        blocks = break_into_blocks(digits, len(digits))
+        length = len(blocks)
+        if length == 2:
+            num_1, num_2 = [as_number(x) for x in blocks]
+            exponent_to_string = stringify_exponent(len(blocks[1]))
+            if num_1 == 1:
+                string = "un {}".format(exponent_to_string)
             else:
-                return as_word + "simo"
+                multiplier = self.to_cardinal(num_1)
+                string = multiplier + " " + exponent_to_string[:-1] + "i"
+            if num_2 != 0:
+                string += " e " + self.to_cardinal(num_2)
+            return string
+        else:
+            pass # TODO *BIG* numbers (> 10^30) support
 
+    def to_cardinal(self, number):
+        if number % 1 != 0:
+            return self.float_to_cardinal(number)
+        if number < 0:
+            return "meno " + self.to_cardinal(-number)
+        if number < 20:
+            return STR_0_to_19[number]
+        elif number < 100:
+            return self.two_digits_to_cardinal(number)
+        elif number < 1000:
+            return self.hundreds_to_cardinal(number)
+        elif number < 1000000:
+            return self.thousands_to_cardinal(number)
+        else:
+            return self.big_exponent_to_cardinal(number)
 
-n2w = Num2Word_IT()
-to_card = n2w.to_cardinal
-to_ord = n2w.to_ordinal
-to_ordnum = n2w.to_ordinal_num
-
+    def to_ordinal(self, n):
+        if n < 0:
+            return "meno " + self.to_ordinal(n)
+        if n == 0:
+            return ZERO
+        if n < 20:
+            return [
+                "primo", "secondo", "terzo", "quarto", "quinto", "sesto",
+                "settimo", "ottavo", "nono", "decimo", "undicesimo",
+                "dodicesimo", "tredicesimo", "quattordicesimo", "quindicesimo",
+                "sedicesimo", "diciassettesimo", "diciassettesimo",
+                "diciannovesimo"
+            ][n-1]
+        else:
+            return self.to_cardinal(n)[:-1] + "esimo"

--- a/num2words/lang_IT.py
+++ b/num2words/lang_IT.py
@@ -135,7 +135,7 @@ class Num2Word_IT(Num2Word_EU):
         mod = number % 100
         is_outside_teens = 0 <= mod <= 10 or mod >= 20
         if number < 0:
-            return "meno " + self.to_ordinal(-n)
+            return "meno " + self.to_ordinal(-number)
         if number == 0:
             return ZERO
         if number < 20:

--- a/num2words/lang_IT.py
+++ b/num2words/lang_IT.py
@@ -62,6 +62,7 @@ class Num2Word_IT(Num2Word_EU):
         pass
 
     def decimal_part_to_cardinal(self, float_number):
+        # Drops the trailing zero and comma
         chars = str(float_number % 1)[2:]
         digits_to_string = [self.to_cardinal(int(d)) for d in chars]
         return " virgola " + " ".join(digits_to_string)
@@ -135,7 +136,6 @@ class Num2Word_IT(Num2Word_EU):
             return self.big_exponent_to_cardinal(number)
 
     def float_to_ordinal(self, float_number):
-        # Drops the trailing zero and comma
         decimal_part_to_string = self.decimal_part_to_cardinal(float_number)
         whole_part_to_string = self.to_ordinal(int(float_number))
         return whole_part_to_string + decimal_part_to_string

--- a/num2words/lang_IT.py
+++ b/num2words/lang_IT.py
@@ -130,18 +130,25 @@ class Num2Word_IT(Num2Word_EU):
         else:
             return self.big_exponent_to_cardinal(number)
 
-    def to_ordinal(self, n):
-        if n < 0:
-            return "meno " + self.to_ordinal(n)
-        if n == 0:
+    def to_ordinal(self, number):
+        # Italian grammar is not very clearly defined here ¯\_(ツ)_/¯
+        mod = number % 100
+        is_outside_teens = 0 <= mod <= 10 or mod >= 20
+        if number < 0:
+            return "meno " + self.to_ordinal(-n)
+        if number == 0:
             return ZERO
-        if n < 20:
+        if number < 20:
             return [
                 "primo", "secondo", "terzo", "quarto", "quinto", "sesto",
                 "settimo", "ottavo", "nono", "decimo", "undicesimo",
                 "dodicesimo", "tredicesimo", "quattordicesimo", "quindicesimo",
-                "sedicesimo", "diciassettesimo", "diciassettesimo",
+                "sedicesimo", "diciassettesimo", "diciottesimo",
                 "diciannovesimo"
-            ][n-1]
+            ][number-1]
+        elif is_outside_teens and number % 10 == 3:
+            return self.to_cardinal(number)[:-1] + "eesimo"
+        elif is_outside_teens and number % 10 == 6:
+            return self.to_cardinal(number) + "esimo"
         else:
-            return self.to_cardinal(n)[:-1] + "esimo"
+            return self.to_cardinal(number)[:-1] + "esimo"

--- a/num2words/lang_IT.py
+++ b/num2words/lang_IT.py
@@ -84,7 +84,7 @@ def omitt_if_zero(number_to_string):
 # Main class
 # ==========
 
-class Num2Word_IT(Num2Word_EU):
+class Num2Word_IT:
 
     MINUS_PREFIX_WORD = "meno "
     FLOAT_INFIX_WORD = " virgola "

--- a/num2words/lang_IT.py
+++ b/num2words/lang_IT.py
@@ -61,11 +61,15 @@ class Num2Word_IT(Num2Word_EU):
     def __init__(self):
         pass
 
+    def decimal_part_to_cardinal(self, float_number):
+        chars = str(float_number % 1)[2:]
+        digits_to_string = [self.to_cardinal(int(d)) for d in chars]
+        return " virgola " + " ".join(digits_to_string)
+
     def float_to_cardinal(self, float_number):
-        decimal_part_as_int = int(str(float_number % 1)[1:])
+        decimal_part_to_string = self.decimal_part_to_cardinal(float_number)
         whole_part_to_string = self.to_cardinal(int(float_number))
-        decimal_part_to_string = self.to_cardinal(decimal_part_as_int)
-        return whole_part_to_string + " virgola " + decimal_part_to_string
+        return whole_part_to_string + decimal_part_to_string
 
     def two_digits_to_cardinal(self, number):
         tens = number // 10
@@ -115,11 +119,11 @@ class Num2Word_IT(Num2Word_EU):
             pass # TODO *BIG* numbers (> 10^30) support
 
     def to_cardinal(self, number):
-        if number % 1 != 0:
-            return self.float_to_cardinal(number)
         if number < 0:
             return "meno " + self.to_cardinal(-number)
-        if number < 20:
+        elif number % 1 != 0:
+            return self.float_to_cardinal(number)
+        elif number < 20:
             return STR_0_to_19[number]
         elif number < 100:
             return self.two_digits_to_cardinal(number)
@@ -130,15 +134,24 @@ class Num2Word_IT(Num2Word_EU):
         else:
             return self.big_exponent_to_cardinal(number)
 
+    def float_to_ordinal(self, float_number):
+        # Drops the trailing zero and comma
+        decimal_part_to_string = self.decimal_part_to_cardinal(float_number)
+        whole_part_to_string = self.to_ordinal(int(float_number))
+        return whole_part_to_string + decimal_part_to_string
+
     def to_ordinal(self, number):
-        # Italian grammar is not very clearly defined here ¯\_(ツ)_/¯
         mod = number % 100
+        # Italian grammar is poorly defined here ¯\_(ツ)_/¯:
+        #   centodecimo VS centodieciesimo VS centesimo decimo?
         is_outside_teens = 0 <= mod <= 10 or mod >= 20
         if number < 0:
             return "meno " + self.to_ordinal(-number)
-        if number == 0:
+        elif number % 1 != 0:
+            return self.float_to_ordinal(number)
+        elif number == 0:
             return ZERO
-        if number < 20:
+        elif number < 20:
             return [
                 "primo", "secondo", "terzo", "quarto", "quinto", "sesto",
                 "settimo", "ottavo", "nono", "decimo", "undicesimo",

--- a/num2words/lang_IT.py
+++ b/num2words/lang_IT.py
@@ -68,7 +68,7 @@ class Num2Word_IT(Num2Word_EU):
         return whole_part_to_string + " virgola " + decimal_part_to_string
 
     def two_digits_to_cardinal(self, number):
-        tens = number / 10
+        tens = number // 10
         units = number % 10
         if tens in STR_TENS:
             tens_to_string = STR_TENS[tens]
@@ -80,7 +80,7 @@ class Num2Word_IT(Num2Word_EU):
         return tens_to_string + units_to_string
 
     def hundreds_to_cardinal(self, number):
-        hundreds = number / 100
+        hundreds = number // 100
         hundreds_to_string = "cento"
         if hundreds != 1:
             hundreds_to_string = STR_0_to_19[hundreds] + hundreds_to_string
@@ -88,7 +88,7 @@ class Num2Word_IT(Num2Word_EU):
         return hundreds_to_string + remainder_to_string
 
     def thousands_to_cardinal(self, number):
-        thousands = number / 1000
+        thousands = number // 1000
         if thousands == 1:
             thousands_to_string = "mille"
         else:

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -15,6 +15,7 @@
 # MA 02110-1301 USA
 
 from __future__ import unicode_literals
+from decimal import Decimal
 from unittest import TestCase
 from num2words import num2words
 
@@ -28,6 +29,23 @@ class Num2WordsITTest(TestCase):
         neg_ord = num2words(-number, lang="it", ordinal=True)
         self.assertEqual("meno " + pos_crd, neg_crd)
         self.assertEqual("meno " + pos_ord, neg_ord)
+
+
+    # We cannot test for equality because of floating point imprecisions.
+    def test_float_to_cardinal(self):
+        number = Decimal(3.1415)
+        s = "tre virgola uno quattro uno "
+        crd_s = num2words(number, lang="it")
+        almost_eq_crd = s + "quattro" in crd_s or s + "cinque" in crd_s
+        self.assertTrue(almost_eq_crd)
+
+    # See above.
+    def test_float_to_ordinal(self):
+        number = Decimal(3.1415)
+        s = "terzo virgola uno quattro uno "
+        ord_s = num2words(number, lang="it", ordinal=True)
+        almost_eq_ord = s + "quattro" in ord_s or s + "cinque" in ord_s
+        self.assertTrue(almost_eq_ord)
 
     def test_0(self):
         self.assertEqual(num2words(0, lang="it"), "zero")
@@ -86,15 +104,6 @@ class Num2WordsITTest(TestCase):
         self.assertEqual(num2words(2000001000, lang="it"), "due miliardi e mille")
         self.assertEqual(num2words(1234567890, lang="it"), "un miliardo e duecentotrentaquattro milioni e cinquecentosessantasettemilaottocentonovanta")
         self.assertEqual(num2words(1000000000000, lang="it"), "un bilione")
-
-    ORDINAL_TEST_CASES = {
-        1: "primo",
-        8: "ottavo",
-        12: "dodicesimo",
-        14: "quattordicesimo",
-        28: "ventottesimo",
-        100: "centesimo"
-    }
 
     def test_nth_0_to_99(self):
         self.assertEqual(num2words(0, lang="it", ordinal=True), "zero")

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -15,7 +15,6 @@
 # MA 02110-1301 USA
 
 from __future__ import unicode_literals
-from decimal import Decimal
 from unittest import TestCase
 from num2words import num2words
 
@@ -33,7 +32,7 @@ class Num2WordsITTest(TestCase):
 
     # We cannot test for equality because of floating point imprecisions.
     def test_float_to_cardinal(self):
-        number = Decimal(3.1415)
+        number = 3.1415
         s = "tre virgola uno quattro uno "
         crd_s = num2words(number, lang="it")
         almost_eq_crd = s + "quattro" in crd_s or s + "cinque" in crd_s
@@ -41,7 +40,7 @@ class Num2WordsITTest(TestCase):
 
     # See above.
     def test_float_to_ordinal(self):
-        number = Decimal(3.1415)
+        number = 3.1415
         s = "terzo virgola uno quattro uno "
         ord_s = num2words(number, lang="it", ordinal=True)
         almost_eq_ord = s + "quattro" in ord_s or s + "cinque" in ord_s

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -20,6 +20,15 @@ from num2words import num2words
 
 class Num2WordsITTest(TestCase):
 
+    def test_negative(self):
+        number = 648972145
+        pos_crd = num2words(+number, lang="it")
+        neg_crd = num2words(-number, lang="it")
+        pos_ord = num2words(+number, lang="it", ordinal=True)
+        neg_ord = num2words(-number, lang="it", ordinal=True)
+        self.assertEqual("meno " + pos_crd, neg_crd)
+        self.assertEqual("meno " + pos_ord, neg_ord)
+
     def test_0(self):
         self.assertEqual(num2words(0, lang="it"), "zero")
 

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -20,6 +20,8 @@ from num2words import num2words
 
 class Num2WordsITTest(TestCase):
 
+    maxDiff = None
+
     def test_negative(self):
         number = 648972145
         pos_crd = num2words(+number, lang="it")
@@ -29,25 +31,19 @@ class Num2WordsITTest(TestCase):
         self.assertEqual("meno " + pos_crd, neg_crd)
         self.assertEqual("meno " + pos_ord, neg_ord)
 
-
-    # We cannot test for equality because of floating point imprecisions.
     def test_float_to_cardinal(self):
-        number = 3.1415
-        s = "tre virgola uno quattro uno "
-        crd_s = num2words(number, lang="it")
-        almost_eq_crd = s + "quattro" in crd_s or s + "cinque" in crd_s
-        self.assertTrue(almost_eq_crd)
+        self.assertTrue("tre virgola uno quattro uno" in num2words(3.1415, lang="it"))
+        self.assertTrue("meno cinque virgola uno" in num2words(-5.15, lang="it"))
+        self.assertTrue("meno zero virgola uno" in num2words(-0.15, lang="it"))
 
-    # See above.
     def test_float_to_ordinal(self):
-        number = 3.1415
-        s = "terzo virgola uno quattro uno "
-        ord_s = num2words(number, lang="it", ordinal=True)
-        almost_eq_ord = s + "quattro" in ord_s or s + "cinque" in ord_s
-        self.assertTrue(almost_eq_ord)
+        self.assertTrue("terzo virgola uno quattro uno" in num2words(3.1415, lang="it", ordinal=True))
+        self.assertTrue("meno quinto virgola uno" in num2words(-5.15, lang="it", ordinal=True))
+        self.assertTrue("meno zero virgola uno" in num2words(-0.15, lang="it", ordinal=True))
 
     def test_0(self):
         self.assertEqual(num2words(0, lang="it"), "zero")
+        self.assertEqual(num2words(0, lang="it", ordinal=True), "zero")
 
     def test_1_to_10(self):
         self.assertEqual(num2words(1, lang="it"), "uno")
@@ -64,6 +60,7 @@ class Num2WordsITTest(TestCase):
 
     def test_20_to_99(self):
         self.assertEqual(num2words(20, lang="it"), "venti")
+        self.assertEqual(num2words(23, lang="it"), "ventitré")
         self.assertEqual(num2words(28, lang="it"), "ventotto")
         self.assertEqual(num2words(31, lang="it"), "trentuno")
         self.assertEqual(num2words(40, lang="it"), "quaranta")
@@ -87,10 +84,12 @@ class Num2WordsITTest(TestCase):
         self.assertEqual(num2words(2000, lang="it"), "duemila")
         self.assertEqual(num2words(2100, lang="it"), "duemilacento")
         self.assertEqual(num2words(6870, lang="it"), "seimilaottocentosettanta")
+        self.assertEqual(num2words(10000, lang="it"), "diecimila")
         self.assertEqual(num2words(98765, lang="it"), "novantottomilasettecentosessantacinque")
-        self.assertEqual(num2words(123456, lang="it"), "centoventitremilaquattrocentocinquantasei")
+        self.assertEqual(num2words(100000, lang="it"), "centomila")
+        self.assertEqual(num2words(523456, lang="it"), "cinquecentoventitremilaquattrocentocinquantasei")
 
-    def test_big_numbers(self):
+    def test_big(self):
         self.assertEqual(num2words(1000000, lang="it"), "un milione")
         self.assertEqual(num2words(1000007, lang="it"), "un milione e sette")
         self.assertEqual(num2words(1200000, lang="it"), "un milione e duecentomila")
@@ -101,11 +100,11 @@ class Num2WordsITTest(TestCase):
         self.assertEqual(num2words(1000000017, lang="it"), "un miliardo e diciassette")
         self.assertEqual(num2words(2000000000, lang="it"), "due miliardi")
         self.assertEqual(num2words(2000001000, lang="it"), "due miliardi e mille")
-        self.assertEqual(num2words(1234567890, lang="it"), "un miliardo e duecentotrentaquattro milioni e cinquecentosessantasettemilaottocentonovanta")
+        self.assertEqual(num2words(1234567890, lang="it"), "un miliardo, duecentotrentaquattro milioni e cinquecentosessantasettemilaottocentonovanta")
         self.assertEqual(num2words(1000000000000, lang="it"), "un bilione")
+        self.assertEqual(num2words(123456789012345678901234567890, lang="it"), "centoventitré quadriliardi, quattrocentocinquantasei quadrilioni, settecentottantanove triliardi, dodici trilioni, trecentoquarantacinque biliardi, seicentosettantotto bilioni, novecentouno miliardi, duecentotrentaquattro milioni e cinquecentosessantasettemilaottocentonovanta")
 
-    def test_nth_0_to_99(self):
-        self.assertEqual(num2words(0, lang="it", ordinal=True), "zero")
+    def test_nth_1_to_99(self):
         self.assertEqual(num2words(1, lang="it", ordinal=True), "primo")
         self.assertEqual(num2words(8, lang="it", ordinal=True), "ottavo")
         self.assertEqual(num2words(23, lang="it", ordinal=True), "ventitreesimo")
@@ -121,8 +120,16 @@ class Num2WordsITTest(TestCase):
         self.assertEqual(num2words(803, lang="it", ordinal=True), "ottocentotreesimo")
         self.assertEqual(num2words(923, lang="it", ordinal=True), "novecentoventitreesimo")
 
-    def test_nth_1000_to_1000000(self):
+    def test_nth_1000_to_999999(self):
         self.assertEqual(num2words(1000, lang="it", ordinal=True), "millesimo")
+        self.assertEqual(num2words(1001, lang="it", ordinal=True), "milleunesimo")
+        self.assertEqual(num2words(1003, lang="it", ordinal=True), "milletreesimo")
         self.assertEqual(num2words(1200, lang="it", ordinal=True), "milleduecentesimo")
+        self.assertEqual(num2words(8640, lang="it", ordinal=True), "ottomilaseicentoquarantesimo")
+        self.assertEqual(num2words(14000, lang="it", ordinal=True), "quattordicimillesimo")
         self.assertEqual(num2words(123456, lang="it", ordinal=True), "centoventitremilaquattrocentocinquantaseiesimo")
-        self.assertEqual(num2words(987654, lang="it", ordinal=True), "novecentoottantasettemilaseicentocinquantaquattresimo")
+        self.assertEqual(num2words(987654, lang="it", ordinal=True), "novecentottantasettemilaseicentocinquantaquattresimo")
+
+    def test_nth_big(self):
+        self.assertEqual(num2words(1000000001, lang="it", ordinal=True), "un miliardo e unesimo")
+        self.assertEqual(num2words(123456789012345678901234567890, lang="it", ordinal=True), "centoventitré quadriliardi, quattrocentocinquantasei quadrilioni, settecentottantanove triliardi, dodici trilioni, trecentoquarantacinque biliardi, seicentosettantotto bilioni, novecentouno miliardi, duecentotrentaquattro milioni e cinquecentosessantasettemilaottocentonovantesimo")

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -15,82 +15,79 @@
 # MA 02110-1301 USA
 
 from __future__ import unicode_literals
-
 from unittest import TestCase
-
 from num2words import num2words
 
 class Num2WordsITTest(TestCase):
 
-    def test_number(self):
+    def test_0(self):
+        self.assertEqual(num2words(0, lang="it"), "zero")
 
-        test_cases = (
-            (1,'uno'),
-            (2,'due'),
-            (3,'tre'),
-            (11,'undici'),
-            (12,'dodici'),
-            (16,'sedici'),
-            (19,'diciannove'),
-            (20,'venti'),
-            (21,'ventuno'),
-            (26,'ventisei'),
-            (28,'ventotto'),
-            (30,'trenta'),
-            (31,'trentuno'),
-            (40,'quaranta'),
-            (43,'quarantatre'),
-            (50,'cinquanta'),
-            (55,'cinquantacinque'),
-            (60,'sessanta'),
-            (67,'sessantasette'),
-            (70,'settanta'),
-            (79,'settantanove'),
-            (100,'cento'),
-            (101,'centouno'),
-            (199,'centonovantanove'),
-            (203,'duecentotre'),
-            (287,'duecentoottantasette'),
-            (300,'trecento'),
-            (356,'trecentocinquantasei'),
-            (410,'quattrocentodieci'),
-            (434,'quattrocentotrentaquattro'),
-            (578,'cinquecentosettantotto'),
-            (689,'seicentoottantanove'),
-            (729,'settecentoventinove'),
-            (894,'ottocentonovantaquattro'),
-            (999,'novecentonovantanove'),
-            (1000,'mille'),
-            (1001,'milleuno'),
-            (1097,'millenovantasette'),
-            (1104,'millecentoquattro'),
-            (1243,'milleduecentoquarantatre'),
-            (2385,'duemilatrecentoottantacinque'),
-            (3766,'tremilasettecentosessantasei'),
-            (4196,'quattromilacentonovantasei'),
-            (5846,'cinquemilaottocentoquarantasei'),
-            (6459,'seimilaquattrocentocinquantanove'),
-            (7232,'settemiladuecentotrentadue'),
-            (8569,'ottomilacinquecentosessantanove'),
-            (9539,'novemilacinquecentotrentanove'),
-            (1000000,'un milione'),
-            (1000001,'un milioneuno'),
-            # (1000000100,'un miliardocento'), # DOES NOT WORK TODO: FIX
-        )
+    def test_1_to_10(self):
+        self.assertEqual(num2words(1, lang="it"), "uno")
+        self.assertEqual(num2words(2, lang="it"), "due")
+        self.assertEqual(num2words(7, lang="it"), "sette")
+        self.assertEqual(num2words(10, lang="it"), "dieci")
 
-        for test in test_cases:
-            self.assertEqual(num2words(test[0], lang='it'), test[1])
+    def test_11_to_19(self):
+        self.assertEqual(num2words(11, lang="it"), "undici")
+        self.assertEqual(num2words(13, lang="it"), "tredici")
+        self.assertEqual(num2words(15, lang="it"), "quindici")
+        self.assertEqual(num2words(16, lang="it"), "sedici")
+        self.assertEqual(num2words(19, lang="it"), "diciannove")
+
+    def test_20_to_99(self):
+        self.assertEqual(num2words(20, lang="it"), "venti")
+        self.assertEqual(num2words(28, lang="it"), "ventotto")
+        self.assertEqual(num2words(31, lang="it"), "trentuno")
+        self.assertEqual(num2words(40, lang="it"), "quaranta")
+        self.assertEqual(num2words(66, lang="it"), "sessantasei")
+        self.assertEqual(num2words(92, lang="it"), "novantadue")
+
+    def test_100_to_999(self):
+        self.assertEqual(num2words(100, lang="it"), "cento")
+        self.assertEqual(num2words(111, lang="it"), "centoundici")
+        self.assertEqual(num2words(150, lang="it"), "centocinquanta")
+        self.assertEqual(num2words(196, lang="it"), "centonovantasei")
+        self.assertEqual(num2words(200, lang="it"), "duecento")
+        self.assertEqual(num2words(210, lang="it"), "duecentodieci")
+        self.assertEqual(num2words(701, lang="it"), "settecentouno")
+
+    def test_1000_to_9999(self):
+        self.assertEqual(num2words(1000, lang="it"), "mille")
+        self.assertEqual(num2words(1001, lang="it"), "milleuno")
+        self.assertEqual(num2words(1500, lang="it"), "millecinquecento")
+        self.assertEqual(num2words(7378, lang="it"), "settemilatrecentosettantotto")
+        self.assertEqual(num2words(2000, lang="it"), "duemila")
+        self.assertEqual(num2words(2100, lang="it"), "duemilacento")
+        self.assertEqual(num2words(6870, lang="it"), "seimilaottocentosettanta")
+        self.assertEqual(num2words(98765, lang="it"), "novantottomilasettecentosessantacinque")
+        self.assertEqual(num2words(123456, lang="it"), "centoventitremilaquattrocentocinquantasei")
+
+    def test_big_numbers(self):
+        self.assertEqual(num2words(1000000, lang="it"), "un milione")
+        self.assertEqual(num2words(1000007, lang="it"), "un milione e sette")
+        self.assertEqual(num2words(1200000, lang="it"), "un milione e duecentomila")
+        self.assertEqual(num2words(3000000, lang="it"), "tre milioni")
+        self.assertEqual(num2words(3000005, lang="it"), "tre milioni e cinque")
+        self.assertEqual(num2words(3800000, lang="it"), "tre milioni e ottocentomila")
+        self.assertEqual(num2words(1000000000, lang="it"), "un miliardo")
+        self.assertEqual(num2words(1000000017, lang="it"), "un miliardo e diciassette")
+        self.assertEqual(num2words(2000000000, lang="it"), "due miliardi")
+        self.assertEqual(num2words(2000001000, lang="it"), "due miliardi e mille")
+        self.assertEqual(num2words(1234567890, lang="it"), "un miliardo e duecentotrentaquattro milioni e cinquecentosessantasettemilaottocentonovanta")
+        self.assertEqual(num2words(1000000000000, lang="it"), "un bilione")
+
+    ORDINAL_TEST_CASES = {
+        1: "primo",
+        8: "ottavo",
+        12: "dodicesimo",
+        14: "quattordicesimo",
+        28: "ventottesimo",
+        100: "centesimo"
+    }
 
     def test_ordinal(self):
-
-        test_cases = (
-            (1,'primo'),
-            (8,'ottavo'),
-            (12,'dodicesimo'),
-            (14,'quattordicesimo'),
-            (28,'ventottesimo'),
-            (100,'centesimo'),
-        )
-
-        for test in test_cases:
-            self.assertEqual(num2words(test[0], lang='it', ordinal=True), test[1])
+        for key in Num2WordsITTest.ORDINAL_TEST_CASES:
+            word = Num2WordsITTest.ORDINAL_TEST_CASES[key]
+            self.assertEqual(num2words(key, lang="it", ordinal=True), word)

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -87,7 +87,25 @@ class Num2WordsITTest(TestCase):
         100: "centesimo"
     }
 
-    def test_ordinal(self):
-        for key in Num2WordsITTest.ORDINAL_TEST_CASES:
-            word = Num2WordsITTest.ORDINAL_TEST_CASES[key]
-            self.assertEqual(num2words(key, lang="it", ordinal=True), word)
+    def test_nth_0_to_99(self):
+        self.assertEqual(num2words(0, lang="it", ordinal=True), "zero")
+        self.assertEqual(num2words(1, lang="it", ordinal=True), "primo")
+        self.assertEqual(num2words(8, lang="it", ordinal=True), "ottavo")
+        self.assertEqual(num2words(23, lang="it", ordinal=True), "ventitreesimo")
+        self.assertEqual(num2words(47, lang="it", ordinal=True), "quarantasettesimo")
+        self.assertEqual(num2words(99, lang="it", ordinal=True), "novantanovesimo")
+
+    def test_nth_100_to_999(self):
+        self.assertEqual(num2words(100, lang="it", ordinal=True), "centesimo")
+        self.assertEqual(num2words(112, lang="it", ordinal=True), "centododicesimo")
+        self.assertEqual(num2words(120, lang="it", ordinal=True), "centoventesimo")
+        self.assertEqual(num2words(316, lang="it", ordinal=True), "trecentosedicesimo")
+        self.assertEqual(num2words(700, lang="it", ordinal=True), "settecentesimo")
+        self.assertEqual(num2words(803, lang="it", ordinal=True), "ottocentotreesimo")
+        self.assertEqual(num2words(923, lang="it", ordinal=True), "novecentoventitreesimo")
+
+    def test_nth_1000_to_1000000(self):
+        self.assertEqual(num2words(1000, lang="it", ordinal=True), "millesimo")
+        self.assertEqual(num2words(1200, lang="it", ordinal=True), "milleduecentesimo")
+        self.assertEqual(num2words(123456, lang="it", ordinal=True), "centoventitremilaquattrocentocinquantaseiesimo")
+        self.assertEqual(num2words(987654, lang="it", ordinal=True), "novecentoottantasettemilaseicentocinquantaquattresimo")


### PR DESCRIPTION
What I did:

- A complete rewrite; the logic is somewhat easier to follow and the code pretty much follows the standard style guidelines.
- More tests.
- Implement the converter for floating point values too.

~Still, TODO~ **Done!:**

- Accents on composite words of "tre" ("ventitré", "centotré", ecc.).
- Commas for numbers larger than `10^30` (i.e. a "quadriliardo").