### PR TITLE
Expose to to_currency.

### DIFF
--- a/num2words/lang_LV.py
+++ b/num2words/lang_LV.py
@@ -279,6 +279,8 @@ class Num2Word_LV(object):
     def to_ordinal(self, number):
         raise NotImplementedError()
 
+    def to_currency(self, n, currency='EUR', cents=True, seperator=','):
+        return to_currency(n, currency, cents, seperator)
 
 if __name__ == '__main__':
     import doctest

--- a/num2words/lang_PL.py
+++ b/num2words/lang_PL.py
@@ -284,6 +284,9 @@ class Num2Word_PL(object):
     def to_ordinal(self, number):
         raise NotImplementedError()
 
+    def to_currency(self, n, currency='EUR', cents=True, seperator=','):
+        return to_currency(n, currency, cents, seperator)
+
 
 if __name__ == '__main__':
     import doctest

--- a/num2words/lang_RU.py
+++ b/num2words/lang_RU.py
@@ -306,6 +306,9 @@ class Num2Word_RU(object):
     def to_ordinal(self, number):
         raise NotImplementedError()
 
+    def to_currency(self, n, currency='EUR', cents=True, seperator=','):
+        return to_currency(n, currency, cents, seperator)
+
 
 if __name__ == '__main__':
     import doctest

--- a/num2words/lang_UK.py
+++ b/num2words/lang_UK.py
@@ -310,6 +310,9 @@ class Num2Word_UK(object):
     def to_ordinal(self, number):
         raise NotImplementedError()
 
+    def to_currency(self, n, currency='EUR', cents=True, seperator=','):
+        return to_currency(n, currency, cents, seperator)
+
 
 if __name__ == '__main__':
     import doctest


### PR DESCRIPTION
Expose `to_currency` where possible.
Did not move existing functions onto converters to prevent API breakage.