### PR TITLE
Fix lang_IT handling of floats

### DIFF
--- a/num2words/lang_IT.py
+++ b/num2words/lang_IT.py
@@ -169,7 +169,7 @@ class Num2Word_IT:
     def to_cardinal(self, number):
         if number < 0:
             string = Num2Word_IT.MINUS_PREFIX_WORD + self.to_cardinal(-number)
-        elif number % 1 != 0:
+        elif isinstance(number, float):
             string = self.float_to_words(number)
         elif number < 20:
             string = CARDINAL_WORDS[number]

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -22,7 +22,6 @@ from num2words import num2words
 
 
 class Num2WordsITTest(TestCase):
-
     maxDiff = None
 
     def test_negative(self):
@@ -224,4 +223,12 @@ class Num2WordsITTest(TestCase):
             "trecentoquarantacinque biliardi, seicentosettantotto bilioni, "
             "novecentouno miliardi, duecentotrentaquattro milioni e "
             "cinquecentosessantasettemilaottocentonovantesimo"
+        )
+
+    def test_with_decimals(self):
+        self.assertAlmostEqual(
+            num2words(1.0, lang="it"), "uno virgola zero"
+        )
+        self.assertAlmostEqual(
+            num2words(1.1, lang="it"), "uno virgola uno"
         )


### PR DESCRIPTION
lang_IT was not detecting floats properly:

```
In [5]: num2words.num2words(4800.0, lang='it')
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-5-9e492d6f2391> in <module>()
----> 1 num2words.num2words(4800.0, lang='it')

/usr/local/lib/python2.7/dist-packages/num2words/__init__.pyc in num2words(number, ordinal, lang, to, **kwargs)
     90         raise NotImplementedError()
     91 
---> 92     return getattr(converter, 'to_{}'.format(to))(number, **kwargs)

/usr/local/lib/python2.7/dist-packages/num2words/lang_IT.pyc in to_cardinal(self, number)
    179             string = self.hundreds_to_cardinal(number)
    180         elif number < 1000000:
--> 181             string = self.thousands_to_cardinal(number)
    182         else:
    183             string = self.big_number_to_cardinal(number)

/usr/local/lib/python2.7/dist-packages/num2words/lang_IT.pyc in thousands_to_cardinal(self, number)
    131             prefix = "mille"
    132         else:
--> 133             prefix = self.to_cardinal(thousands) + "mila"
    134         postfix = omitt_if_zero(self.to_cardinal(number % 1000))
    135         # "mille" and "mila" don't need any phonetic contractions

/usr/local/lib/python2.7/dist-packages/num2words/lang_IT.pyc in to_cardinal(self, number)
    173             string = self.float_to_words(number)
    174         elif number < 20:
--> 175             string = CARDINAL_WORDS[number]
    176         elif number < 100:
    177             string = self.tens_to_cardinal(number)

TypeError: list indices must be integers, not float
```

but it would work with any other deciman number != 0. 

The problem is in the test for floats: `n % 1 != 0` is not a valid test:

In []: 1.1 % 1 == 0
Out[]: False

but:

In []: 1.0 % 1 == 0
Out[]: True

hence it's really necessary to explicitly test for type in this case.

### Status

- [ X] READY
- [ ] HOLD



