### PR TITLE
lang_EN.to_year(): render correct pronunciations

### DIFF
--- a/num2words/lang_EN.py
+++ b/num2words/lang_EN.py
@@ -82,16 +82,24 @@ class Num2Word_EN(lang_EU.Num2Word_EU):
         self.verify_ordinal(value)
         return "%s%s" % (value, self.to_ordinal(value)[-2:])
 
-    def to_year(self, val, longval=True):
+    def to_year(self, val, suffix=None, longval=True):
+        if val < 0:
+            val = abs(val)
+            suffix = 'BC' if not suffix else suffix
         high, low = (val // 100, val % 100)
-        # If year is beyond 9999 or is X00X, go cardinal.
-        if high >= 100 or (high % 10 == 0 and low < 10):
-            return self.to_cardinal(val)
-        hightext = self.to_cardinal(high)
-        if low == 0:
-            lowtext = "hundred"
-        elif low < 10:
-            lowtext = "oh-%s" % self.to_cardinal(low)
+        # If year is 00XX, X00X, or beyond 9999, go cardinal.
+        if (high == 0
+                or (high % 10 == 0 and low < 10)
+                or high >= 100):
+            valtext = self.to_cardinal(val)
         else:
-            lowtext = self.to_cardinal(low)
-        return "%s %s" % (hightext, lowtext)
+            hightext = self.to_cardinal(high)
+            if low == 0:
+                lowtext = "hundred"
+            elif low < 10:
+                lowtext = "oh-%s" % self.to_cardinal(low)
+            else:
+                lowtext = self.to_cardinal(low)
+            valtext = "%s %s" % (hightext, lowtext)
+        return (valtext if not suffix
+                else "%s %s" % (valtext, suffix))

--- a/num2words/lang_EN.py
+++ b/num2words/lang_EN.py
@@ -83,7 +83,15 @@ class Num2Word_EN(lang_EU.Num2Word_EU):
         return "%s%s" % (value, self.to_ordinal(value)[-2:])
 
     def to_year(self, val, longval=True):
-        if not (val // 100) % 10:
+        high, low = (val // 100, val % 100)
+        # If year is beyond 9999 or is X00X, go cardinal.
+        if high >= 100 or (high % 10 == 0 and low < 10):
             return self.to_cardinal(val)
-        return self.to_splitnum(val, hightxt="hundred", jointxt="and",
-                                longval=longval)
+        hightext = self.to_cardinal(high)
+        if low == 0:
+            lowtext = "hundred"
+        elif low < 10:
+            lowtext = "oh-%s" % self.to_cardinal(low)
+        else:
+            lowtext = self.to_cardinal(low)
+        return "%s %s" % (hightext, lowtext)

--- a/tests/test_en.py
+++ b/tests/test_en.py
@@ -64,33 +64,33 @@ class Num2WordsENTest(TestCase):
         # issue 141
         # "e2 e2"
         self.assertEqual(num2words(1990, lang='en', to='year'),
-                'nineteen ninety')
+                         'nineteen ninety')
         self.assertEqual(num2words(5555, lang='en', to='year'),
-                'fifty-five fifty-five')
+                         'fifty-five fifty-five')
         self.assertEqual(num2words(2017, lang='en', to='year'),
-                'twenty seventeen')
+                         'twenty seventeen')
         self.assertEqual(num2words(1066, lang='en', to='year'),
-                'ten sixty-six')
+                         'ten sixty-six')
         self.assertEqual(num2words(1865, lang='en', to='year'),
-                'eighteen sixty-five')
+                         'eighteen sixty-five')
         # "e3 and e1"; "e2 oh-e1"; "e3"
         self.assertEqual(num2words(3000, lang='en', to='year'),
-                'three thousand')
+                         'three thousand')
         self.assertEqual(num2words(2001, lang='en', to='year'),
-                'two thousand and one')
+                         'two thousand and one')
         self.assertEqual(num2words(1901, lang='en', to='year'),
-                'nineteen oh-one')
+                         'nineteen oh-one')
         self.assertEqual(num2words(2000, lang='en', to='year'),
-                'two thousand')
+                         'two thousand')
         self.assertEqual(num2words(905, lang='en', to='year'),
-                'nine oh-five')
+                         'nine oh-five')
         # "e2 hundred"; "e3"
         self.assertEqual(num2words(6600, lang='en', to='year'),
-                'sixty-six hundred')
+                         'sixty-six hundred')
         self.assertEqual(num2words(1900, lang='en', to='year'),
-                'nineteen hundred')
+                         'nineteen hundred')
         self.assertEqual(num2words(600, lang='en', to='year'),
-                'six hundred')
+                         'six hundred')
         self.assertEqual(num2words(0, lang='en', to='year'),
-                'zero')
+                         'zero')
         # COMBAK: Negative numbers: append BCE?

--- a/tests/test_en.py
+++ b/tests/test_en.py
@@ -91,6 +91,19 @@ class Num2WordsENTest(TestCase):
                          'nineteen hundred')
         self.assertEqual(num2words(600, lang='en', to='year'),
                          'six hundred')
+        self.assertEqual(num2words(50, lang='en', to='year'),
+                         'fifty')
         self.assertEqual(num2words(0, lang='en', to='year'),
                          'zero')
-        # COMBAK: Negative numbers: append BCE?
+        # suffixes
+        self.assertEqual(num2words(-44, lang='en', to='year'),
+                         'forty-four BC')
+        self.assertEqual(num2words(-44, lang='en', to='year', suffix='BCE'),
+                         'forty-four BCE')
+        self.assertEqual(num2words(1, lang='en', to='year', suffix='AD'),
+                         'one AD')
+        self.assertEqual(num2words(66, lang='en', to='year',
+                                   suffix='m.y.a.'),
+                         'sixty-six m.y.a.')
+        self.assertEqual(num2words(-66000000, lang='en', to='year'),
+                         'sixty-six million BC')

--- a/tests/test_en.py
+++ b/tests/test_en.py
@@ -59,3 +59,38 @@ class Num2WordsENTest(TestCase):
                       cents=True, currency='USD'),
             'four thousand, seven hundred and seventy-eight dollars and'
             ' zero cents')
+
+    def test_to_year(self):
+        # issue 141
+        # "e2 e2"
+        self.assertEqual(num2words(1990, lang='en', to='year'),
+                'nineteen ninety')
+        self.assertEqual(num2words(5555, lang='en', to='year'),
+                'fifty-five fifty-five')
+        self.assertEqual(num2words(2017, lang='en', to='year'),
+                'twenty seventeen')
+        self.assertEqual(num2words(1066, lang='en', to='year'),
+                'ten sixty-six')
+        self.assertEqual(num2words(1865, lang='en', to='year'),
+                'eighteen sixty-five')
+        # "e3 and e1"; "e2 oh-e1"; "e3"
+        self.assertEqual(num2words(3000, lang='en', to='year'),
+                'three thousand')
+        self.assertEqual(num2words(2001, lang='en', to='year'),
+                'two thousand and one')
+        self.assertEqual(num2words(1901, lang='en', to='year'),
+                'nineteen oh-one')
+        self.assertEqual(num2words(2000, lang='en', to='year'),
+                'two thousand')
+        self.assertEqual(num2words(905, lang='en', to='year'),
+                'nine oh-five')
+        # "e2 hundred"; "e3"
+        self.assertEqual(num2words(6600, lang='en', to='year'),
+                'sixty-six hundred')
+        self.assertEqual(num2words(1900, lang='en', to='year'),
+                'nineteen hundred')
+        self.assertEqual(num2words(600, lang='en', to='year'),
+                'six hundred')
+        self.assertEqual(num2words(0, lang='en', to='year'),
+                'zero')
+        # COMBAK: Negative numbers: append BCE?


### PR DESCRIPTION
## Fixes #141

### Changes proposed in this pull request:

* Rework lang_EN.to_year() to account for canonical year pronunciations ("twenty seventeen", etc.).
* Add unit tests for the same.