### PR TITLE
Added support for es_MX

### DIFF
--- a/num2words/__init__.py
+++ b/num2words/__init__.py
@@ -37,6 +37,7 @@ from . import lang_HE
 from . import lang_IT
 from . import lang_ES_VE
 from . import lang_ES_CO
+from . import lang_ES_MX
 from . import lang_VN
 from . import lang_TR
 from . import lang_NL
@@ -55,6 +56,7 @@ CONVERTER_CLASSES = {
     'de': lang_DE.Num2Word_DE(),
     'es': lang_ES.Num2Word_ES(),
     'es_CO': lang_ES_CO.Num2Word_ES_CO(),
+    'es_MX': lang_ES_MX.Num2Word_ES_MX(),
     'es_VE': lang_ES_VE.Num2Word_ES_VE(),
     'id': lang_ID.Num2Word_ID(),
     'lt': lang_LT.Num2Word_LT(),

--- a/num2words/lang_ES_MX.py
+++ b/num2words/lang_ES_MX.py
@@ -1,0 +1,33 @@
+# encoding: UTF-8
+
+# Copyright (c) 2003, Taro Ogawa.  All Rights Reserved.
+# Copyright (c) 2013, Savoir-faire Linux inc.  All Rights Reserved.
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301 USA
+
+from __future__ import print_function, unicode_literals
+
+from .lang_ES import Num2Word_ES
+from .currency import parse_currency_parts
+
+
+class Num2Word_ES_MX(Num2Word_ES):
+
+    def to_currency(self, val, longval=True, old=False):
+        left, right, is_negative = parse_currency_parts(val, is_int_with_cents=False)
+        result = self.to_splitnum(left, hightxt="peso/s",
+                                  divisor=1, longval=longval, cents=False)
+        result = "%s, %02d/100 M. N." % (result, right)
+        # Handle exception, in spanish is "un euro" and not "uno euro"
+        return result.replace("uno", "un")

--- a/num2words/lang_ES_MX.py
+++ b/num2words/lang_ES_MX.py
@@ -18,8 +18,8 @@
 
 from __future__ import print_function, unicode_literals
 
-from .lang_ES import Num2Word_ES
 from .currency import parse_currency_parts
+from .lang_ES import Num2Word_ES
 
 
 class Num2Word_ES_MX(Num2Word_ES):

--- a/num2words/lang_ES_MX.py
+++ b/num2words/lang_ES_MX.py
@@ -25,7 +25,9 @@ from .currency import parse_currency_parts
 class Num2Word_ES_MX(Num2Word_ES):
 
     def to_currency(self, val, longval=True, old=False):
-        left, right, is_negative = parse_currency_parts(val, is_int_with_cents=False)
+        left, right, is_negative = parse_currency_parts(
+            val, is_int_with_cents=False
+        )
         result = self.to_splitnum(left, hightxt="peso/s",
                                   divisor=1, longval=longval, cents=False)
         result = "%s, %02d/100 M. N." % (result, right)

--- a/tests/test_es_mx.py
+++ b/tests/test_es_mx.py
@@ -1,0 +1,59 @@
+# encoding: UTF-8
+# Copyright (c) 2013, Savoir-faire Linux inc.  All Rights Reserved.
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301 USA
+
+from __future__ import unicode_literals
+
+from num2words import num2words
+
+from . import test_es
+
+TEST_CASES_TO_CURRENCY = (
+    (1, 'un peso, 00/100 M. N.'),
+    (2, 'dos pesos, 00/100 M. N.'),
+    (8, 'ocho pesos, 00/100 M. N.'),
+    (12, 'doce pesos, 00/100 M. N.'),
+    (21, 'veintiun pesos, 00/100 M. N.'),
+    (81.25, 'ochenta y un pesos, 25/100 M. N.'),
+    (100, 'cien pesos, 00/100 M. N.'),
+)
+
+
+class Num2WordsESMXTest(test_es.Num2WordsESTest):
+
+    def test_number(self):
+        for test in test_es.TEST_CASES_CARDINAL:
+            self.assertEqual(num2words(test[0], lang='es_MX'), test[1])
+
+    def test_ordinal(self):
+        for test in test_es.TEST_CASES_ORDINAL:
+            self.assertEqual(
+                num2words(test[0], lang='es_MX', ordinal=True),
+                test[1]
+            )
+
+    def test_ordinal_num(self):
+        for test in test_es.TEST_CASES_ORDINAL_NUM:
+            self.assertEqual(
+                num2words(test[0], lang='es_MX', to='ordinal_num'),
+                test[1]
+            )
+
+    def test_currency(self):
+        for test in TEST_CASES_TO_CURRENCY:
+            self.assertEqual(
+                num2words(test[0], lang='es_MX', to='currency'),
+                test[1]
+            )


### PR DESCRIPTION
## Feature  by Salvador Martinez (chavamm83@gmail.com)

### Changes proposed in this pull request:

* Added support for es_MX currency (MXN)

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change
```python
import num2words
a = 1234.01
print num2words.num2words(a, to='currency', lang='es_MX')
```
>OUTPUT >>> mil doscientos treinta y cuatro pesos, 01/100 M. N.
### Additional notes
