### PR TITLE
Adding support for es_GT

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,7 @@ Besides the numerical argument, there's two optional arguments.
 * ``es`` (Spanish)
 * ``es_CO`` (Spanish - Colombia)
 * ``es_VE`` (Spanish - Venezuela)
+* ``es_GT`` (Spanish - Guatemala)
 * ``eu`` (EURO)
 * ``fr`` (French)
 * ``fr_CH`` (French - Switzerland)

--- a/num2words/__init__.py
+++ b/num2words/__init__.py
@@ -37,6 +37,7 @@ from . import lang_HE
 from . import lang_IT
 from . import lang_ES_VE
 from . import lang_ES_CO
+from . import lang_ES_GT
 from . import lang_VN
 from . import lang_TR
 from . import lang_NL
@@ -56,6 +57,7 @@ CONVERTER_CLASSES = {
     'es': lang_ES.Num2Word_ES(),
     'es_CO': lang_ES_CO.Num2Word_ES_CO(),
     'es_VE': lang_ES_VE.Num2Word_ES_VE(),
+    'es_GT': lang_ES_GT.Num2Word_ES_GT(),
     'id': lang_ID.Num2Word_ID(),
     'lt': lang_LT.Num2Word_LT(),
     'lv': lang_LV.Num2Word_LV(),

--- a/num2words/lang_ES_GT.py
+++ b/num2words/lang_ES_GT.py
@@ -1,0 +1,30 @@
+# encoding: UTF-8
+
+# Copyright (c) 2003, Taro Ogawa.  All Rights Reserved.
+# Copyright (c) 2013, Savoir-faire Linux inc.  All Rights Reserved.
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301 USA
+
+from __future__ import print_function, unicode_literals
+
+from .lang_ES import Num2Word_ES
+
+
+class Num2Word_ES_GT(Num2Word_ES):
+
+    def to_currency(self, val, longval=True, old=False):
+        result = self.to_splitnum(val, hightxt="quetzal/es", lowtxt="centavo/s",
+                                  divisor=1, jointxt="y", longval=longval)
+        # Handle exception, in spanish is "un euro" and not "uno euro"
+        return result.replace("uno", "un")

--- a/tests/test_es_gt.py
+++ b/tests/test_es_gt.py
@@ -1,0 +1,59 @@
+# encoding: UTF-8
+# Copyright (c) 2013, Savoir-faire Linux inc.  All Rights Reserved.
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301 USA
+
+from __future__ import unicode_literals
+
+from num2words import num2words
+
+from . import test_es
+
+TEST_CASES_TO_CURRENCY = (
+    (1, 'un quetzal'),
+    (2, 'dos quetzales'),
+    (8, 'ocho quetzales'),
+    (12, 'doce quetzales'),
+    (21, 'veintiun quetzales'),
+    (81.25, 'ochenta y un quetzales y veinticinco centavos'),
+    (100, 'cien quetzales'),
+)
+
+
+class Num2WordsESCOTest(test_es.Num2WordsESTest):
+
+    def test_number(self):
+        for test in test_es.TEST_CASES_CARDINAL:
+            self.assertEqual(num2words(test[0], lang='es_GT'), test[1])
+
+    def test_ordinal(self):
+        for test in test_es.TEST_CASES_ORDINAL:
+            self.assertEqual(
+                num2words(test[0], lang='es_GT', ordinal=True),
+                test[1]
+            )
+
+    def test_ordinal_num(self):
+        for test in test_es.TEST_CASES_ORDINAL_NUM:
+            self.assertEqual(
+                num2words(test[0], lang='es', to='ordinal_num'),
+                test[1]
+            )
+
+    def test_currency(self):
+        for test in TEST_CASES_TO_CURRENCY:
+            self.assertEqual(
+                num2words(test[0], lang='es_GT', to='currency'),
+                test[1]
+            )


### PR DESCRIPTION
## Fixes # by (m.monroyc22@gmail.com)

### Changes proposed in this pull request:

* support for es_GT
* ...

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

```import num2words
a = 1334.12
print num2words.num2words(a, to='currency', lang='es_GT')
```
OUTPUT >>> mil trescientos treinta y cuatro quetzales y doce centavos

### Additional notes

*If applicable, explain the rationale behind your change.*

