### PR TITLE
Added support for es_MX language

### DIFF
--- a/num2words/__init__.py
+++ b/num2words/__init__.py
@@ -38,6 +38,7 @@ from . import lang_HE
 from . import lang_IT
 from . import lang_ES_VE
 from . import lang_ES_CO
+from . import lang_ES_MX
 from . import lang_VN
 from . import lang_TR
 from . import lang_NL
@@ -57,6 +58,7 @@ CONVERTER_CLASSES = {
     'de': lang_DE.Num2Word_DE(),
     'es': lang_ES.Num2Word_ES(),
     'es_CO': lang_ES_CO.Num2Word_ES_CO(),
+    'es_MX': lang_ES_MX.Num2Word_ES_MX(),
     'es_VE': lang_ES_VE.Num2Word_ES_VE(),
     'id': lang_ID.Num2Word_ID(),
     'lt': lang_LT.Num2Word_LT(),

--- a/num2words/base.py
+++ b/num2words/base.py
@@ -258,7 +258,7 @@ class Num2Word_Base(object):
         return self.to_cardinal(number)
 
     def to_currency(self, val, currency='EUR', cents=True, seperator=',',
-                    adjective=False):
+                    adjective=False, is_int_with_cents=True):
         """
         Args:
             val: Numeric value
@@ -270,7 +270,9 @@ class Num2Word_Base(object):
             str: Formatted string
 
         """
-        left, right, is_negative = parse_currency_parts(val)
+        left, right, is_negative = parse_currency_parts(
+            val, is_int_with_cents=is_int_with_cents,
+        )
 
         try:
             cr1, cr2 = self.CURRENCY_FORMS[currency]

--- a/num2words/lang_ES.py
+++ b/num2words/lang_ES.py
@@ -20,8 +20,39 @@ from __future__ import print_function, unicode_literals
 
 from .lang_EU import Num2Word_EU
 
+GENERIC_DOLLARS = ('dolar', 'dolares')
+GENERIC_CENTS = ('centavo', 'centavos')
+
 
 class Num2Word_ES(Num2Word_EU):
+    CURRENCY_FORMS = {
+        'AUD': (GENERIC_DOLLARS, GENERIC_CENTS),
+        'CAD': (GENERIC_DOLLARS, GENERIC_CENTS),
+        # repalced by EUR
+        'EEK': (('corona', 'coronas'), ('céntimo', 'céntmos')),
+        'EUR': (('euro', 'euros'), GENERIC_CENTS),
+        'GBP': (('libra esterlina', 'libras esterlinas'), ('penique', 'peniques')),  # noqa
+        # replaced by EUR
+        'LTL': (('lita', 'litas'), GENERIC_CENTS),
+        # replaced by EUR
+        'LVL': (('lat', 'lats'), ('santims', 'santimu')),
+        'USD': (GENERIC_DOLLARS, GENERIC_CENTS),
+        'RUB': (('rublo', 'rublos'), ('kopek', 'kopeks')),
+        'SEK': (('corona', 'coronas'), ('öre', 'öre')),
+        'NOK': (('corona', 'coronas'), ('øre', 'øre')),
+        'PLN': (('zloty', 'zlotys'), ('grosz', 'groszy')),
+    }
+
+    CURRENCY_ADJECTIVES = {
+        'AUD': 'Australiano',
+        'CAD': 'Canadiense',
+        'EEK': 'Estonia',
+        'USD': 'Americano',
+        'RUB': 'Ruso',
+        'SEK': 'Sueca',
+        'NOK': 'Noruega',
+    }
+
     # //CHECK: Is this sufficient??
     def set_high_numwords(self, high):
         max = 3 + 6 * len(high)
@@ -165,11 +196,12 @@ class Num2Word_ES(Num2Word_EU):
         self.verify_ordinal(value)
         return "%s%s" % (value, "º" if self.gender_stem == 'o' else "ª")
 
-    def to_currency(self, val, longval=True, old=False):
-        hightxt, lowtxt = "euro/s", "centavo/s"
-        if old:
-            hightxt, lowtxt = "peso/s", "peseta/s"
-        result = self.to_splitnum(val, hightxt=hightxt, lowtxt=lowtxt,
-                                  divisor=1, jointxt="y", longval=longval)
+    def to_currency(self, val, currency='EUR', cents=True, seperator=' y',
+                    adjective=False, is_int_with_cents=False):
+        result = super(Num2Word_ES, self).to_currency(
+            val, currency=currency, cents=cents, seperator=seperator,
+            adjective=adjective, is_int_with_cents=is_int_with_cents,
+        )
         # Handle exception, in spanish is "un euro" and not "uno euro"
-        return result.replace("uno", "un")
+        result = result.replace("uno", "un")
+        return result

--- a/num2words/lang_ES_MX.py
+++ b/num2words/lang_ES_MX.py
@@ -1,0 +1,33 @@
+# encoding: UTF-8
+
+# Copyright (c) 2003, Taro Ogawa.  All Rights Reserved.
+# Copyright (c) 2013, Savoir-faire Linux inc.  All Rights Reserved.
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301 USA
+
+from __future__ import print_function, unicode_literals
+
+from .lang_ES import Num2Word_ES
+from .currency import parse_currency_parts
+
+
+class Num2Word_ES_MX(Num2Word_ES):
+
+    def to_currency(self, val, longval=True, old=False):
+        left, right, is_negative = parse_currency_parts(val, is_int_with_cents=False)
+        result = self.to_splitnum(left, hightxt="peso/s",
+                                  divisor=1, longval=longval, cents=False)
+        result = "%s, %02d/100 M. N." % (result, right)
+        # Handle exception, in spanish is "un euro" and not "uno euro"
+        return result.replace("uno", "un")

--- a/num2words/lang_ES_MX.py
+++ b/num2words/lang_ES_MX.py
@@ -18,8 +18,8 @@
 
 from __future__ import print_function, unicode_literals
 
-from .lang_ES import Num2Word_ES
 from .currency import parse_currency_parts
+from .lang_ES import Num2Word_ES
 
 
 class Num2Word_ES_MX(Num2Word_ES):

--- a/num2words/lang_ES_MX.py
+++ b/num2words/lang_ES_MX.py
@@ -25,7 +25,9 @@ from .currency import parse_currency_parts
 class Num2Word_ES_MX(Num2Word_ES):
 
     def to_currency(self, val, longval=True, old=False):
-        left, right, is_negative = parse_currency_parts(val, is_int_with_cents=False)
+        left, right, is_negative = parse_currency_parts(
+            val, is_int_with_cents=False
+        )
         result = self.to_splitnum(left, hightxt="peso/s",
                                   divisor=1, longval=longval, cents=False)
         result = "%s, %02d/100 M. N." % (result, right)

--- a/num2words/lang_ES_MX.py
+++ b/num2words/lang_ES_MX.py
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 
-# Copyright (c) 2003, Taro Ogawa.  All Rights Reserved.
-# Copyright (c) 2013, Savoir-faire Linux inc.  All Rights Reserved.
+# Copyright (c) 2018, Agustín Cruz <agustin.cruz@openpyme.mx>.
+# All Rights Reserved.
 
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -16,20 +16,35 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 # MA 02110-1301 USA
 
-from __future__ import print_function, unicode_literals
 
-from .currency import parse_currency_parts
 from .lang_ES import Num2Word_ES
 
 
 class Num2Word_ES_MX(Num2Word_ES):
+    CURRENCY_FORMS = {
+        'USD': (
+            ('dolar', 'dolares'), ('', '')
+        ),
+        'EUR': (
+            ('euro', 'euros'), ('', '')
+        ),
+        'MXN': (
+            ('peso', 'pesos'), ('', '')
+        ),
+    }
 
-    def to_currency(self, val, longval=True, old=False):
-        left, right, is_negative = parse_currency_parts(
-            val, is_int_with_cents=False
+    def _cents_verbose(self, number, currency):
+        return '%02d/100' % number
+
+    def to_currency(self, val, currency='MXN', cents=True, seperator=',',
+                    adjective=False, is_int_with_cents=False):
+        result = super(Num2Word_ES_MX, self).to_currency(
+            val, currency=currency, cents=cents, seperator=seperator,
+            adjective=adjective, is_int_with_cents=is_int_with_cents,
         )
-        result = self.to_splitnum(left, hightxt="peso/s",
-                                  divisor=1, longval=longval, cents=False)
-        result = "%s, %02d/100 M. N." % (result, right)
-        # Handle exception, in spanish is "un euro" and not "uno euro"
-        return result.replace("uno", "un")
+        if currency == 'MXN':
+            result += 'M. N.'
+        else:
+            result += currency
+
+        return result

--- a/tests/test_es.py
+++ b/tests/test_es.py
@@ -110,23 +110,13 @@ TEST_CASES_ORDINAL_NUM = (
 )
 
 TEST_CASES_TO_CURRENCY = (
-    (1, 'un euro'),
-    (2, 'dos euros'),
-    (8, 'ocho euros'),
-    (12, 'doce euros'),
-    (21, 'veintiun euros'),
+    (1, 'un euro y cero centavos'),
+    (2, 'dos euros y cero centavos'),
+    (8, 'ocho euros y cero centavos'),
+    (12, 'doce euros y cero centavos'),
+    (21, 'veintiun euros y cero centavos'),
     (81.25, 'ochenta y un euros y veinticinco centavos'),
-    (100, 'cien euros'),
-)
-
-TEST_CASES_TO_CURRENCY_OLD = (
-    (1, 'un peso'),
-    (2, 'dos pesos'),
-    (8, 'ocho pesos'),
-    (12, 'doce pesos'),
-    (21, 'veintiun pesos'),
-    (81.25, 'ochenta y un pesos y veinticinco pesetas'),
-    (100, 'cien pesos'),
+    (100, 'cien euros y cero centavos'),
 )
 
 
@@ -154,12 +144,5 @@ class Num2WordsESTest(TestCase):
         for test in TEST_CASES_TO_CURRENCY:
             self.assertEqual(
                 num2words(test[0], lang='es', to='currency'),
-                test[1]
-            )
-
-    def test_currency_old(self):
-        for test in TEST_CASES_TO_CURRENCY_OLD:
-            self.assertEqual(
-                num2words(test[0], lang='es', to='currency', old=True),
                 test[1]
             )

--- a/tests/test_es_mx.py
+++ b/tests/test_es_mx.py
@@ -1,0 +1,59 @@
+# encoding: UTF-8
+# Copyright (c) 2013, Savoir-faire Linux inc.  All Rights Reserved.
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301 USA
+
+from __future__ import unicode_literals
+
+from num2words import num2words
+
+from . import test_es
+
+TEST_CASES_TO_CURRENCY = (
+    (1, 'un peso, 00/100 M. N.'),
+    (2, 'dos pesos, 00/100 M. N.'),
+    (8, 'ocho pesos, 00/100 M. N.'),
+    (12, 'doce pesos, 00/100 M. N.'),
+    (21, 'veintiun pesos, 00/100 M. N.'),
+    (81.25, 'ochenta y un pesos, 25/100 M. N.'),
+    (100, 'cien pesos, 00/100 M. N.'),
+)
+
+
+class Num2WordsESMXTest(test_es.Num2WordsESTest):
+
+    def test_number(self):
+        for test in test_es.TEST_CASES_CARDINAL:
+            self.assertEqual(num2words(test[0], lang='es_MX'), test[1])
+
+    def test_ordinal(self):
+        for test in test_es.TEST_CASES_ORDINAL:
+            self.assertEqual(
+                num2words(test[0], lang='es_MX', ordinal=True),
+                test[1]
+            )
+
+    def test_ordinal_num(self):
+        for test in test_es.TEST_CASES_ORDINAL_NUM:
+            self.assertEqual(
+                num2words(test[0], lang='es_MX', to='ordinal_num'),
+                test[1]
+            )
+
+    def test_currency(self):
+        for test in TEST_CASES_TO_CURRENCY:
+            self.assertEqual(
+                num2words(test[0], lang='es_MX', to='currency'),
+                test[1]
+            )


### PR DESCRIPTION
### Changes proposed in this pull request:

* Added support for es_MX currency (MXN)

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change
```python
import num2words
a = 1234.01
print num2words.num2words(a, to='currency', lang='es_MX')
```
### Additional notes

This replace @chavamm work done in #152

