### PR TITLE
Added function to_check that creates a number suitable for writing on…

### DIFF
--- a/num2words/__init__.py
+++ b/num2words/__init__.py
@@ -77,7 +77,7 @@ CONVERTER_CLASSES = {
 }
 
 
-CONVERTES_TYPES = ['cardinal', 'ordinal', 'ordinal_num', 'year', 'currency']
+CONVERTES_TYPES = ['cardinal', 'ordinal', 'ordinal_num', 'year', 'currency', 'check']
 
 
 def num2words(number, ordinal=False, lang='en', to='cardinal', **kwargs):

--- a/num2words/base.py
+++ b/num2words/base.py
@@ -296,6 +296,16 @@ class Num2Word_Base(object):
             self.pluralize(right, cr2)
         )
 
+    def to_check(self, val):
+        """Formats for printing on a check that already has currency spelled out
+
+        Args:
+            val: Numeric value
+        Returns:
+            str: Formatted string
+        """
+        raise NotImplementedError("to_check not implemented for this language")
+
     def base_setup(self):
         pass
 

--- a/num2words/lang_EN.py
+++ b/num2words/lang_EN.py
@@ -17,6 +17,7 @@
 from __future__ import division, print_function, unicode_literals
 
 from . import lang_EU
+from .currency import parse_currency_parts, prefix_currency
 
 
 class Num2Word_EN(lang_EU.Num2Word_EU):
@@ -103,3 +104,22 @@ class Num2Word_EN(lang_EU.Num2Word_EU):
             valtext = "%s %s" % (hightext, lowtext)
         return (valtext if not suffix
                 else "%s %s" % (valtext, suffix))
+
+    def to_check(self, val):
+        """Formats for printing on a check that already has currency spelled out
+
+        Args:
+            val: Numeric value
+        Returns:
+            str: Formatted string
+        """
+        left, right, is_negative = parse_currency_parts(val)
+        if is_negative:
+            raise ValueError("Amount cannot be negative on a check")
+
+        cents_str = "and %2d/100" % right if right > 0 else "and XX/100"
+
+        cardinal = self.to_cardinal(left).replace(' and','').replace(',','')
+        
+        return u'%s %s' % (cardinal, cents_str)
+    


### PR DESCRIPTION
… a check.

### Changes proposed in this pull request:

* American bank check word style
* Complains if language is not English

### Status

- [ ] READY
- [ ] HOLD
- [X] WIP (Work-In-Progress)

### How to verify this change

Call num2words with to='check'

### Additional notes

The words on a check should read like "one thousand three hundred forty-seven and 33/100" (1,347.33) or "five hundred ninety-six and xx/100". (596.00) The "dollars" is usually left off because it is already on the check, but it could be added at the end by the user. 

Ideally it would also say "exactly thirty-five cents" for the cases where the amount is less than $1. But I
did not implement this function as I do not need it.

I have no idea what it should look like in other countries/languages so I left them out.