### PR TITLE
Change implementation of to_currency() in es_ES

### DIFF
--- a/num2words/lang_ES.py
+++ b/num2words/lang_ES.py
@@ -18,8 +18,6 @@
 
 from __future__ import print_function, unicode_literals
 
-from .currency import parse_currency_parts
-
 from .lang_EU import Num2Word_EU
 
 

--- a/num2words/lang_ES.py
+++ b/num2words/lang_ES.py
@@ -25,6 +25,7 @@ class Num2Word_ES(Num2Word_EU):
     CURRENCY_FORMS = {
         'EUR': (('euro', 'euros'), ('centimo', 'centimos')),
         'ESP': (('peseta', 'pesetas'), ('centimo', 'centimos')),
+        'USD': (('dolar', 'dolares'), ('centavo', 'centavos')),
     }
 
     # //CHECK: Is this sufficient??
@@ -171,9 +172,7 @@ class Num2Word_ES(Num2Word_EU):
         return "%s%s" % (value, "º" if self.gender_stem == 'o' else "ª")
 
     def to_currency(self, val, currency='EUR', cents=True, seperator=' con',
-                    adjective=False, old=False):
-        if old:
-            currency = 'ESP'
+                    adjective=False):
         result = super(Num2Word_ES, self).to_currency(
             val, currency=currency, cents=cents, seperator=seperator,
             adjective=adjective)

--- a/num2words/lang_ES.py
+++ b/num2words/lang_ES.py
@@ -18,10 +18,17 @@
 
 from __future__ import print_function, unicode_literals
 
+from .currency import parse_currency_parts
+
 from .lang_EU import Num2Word_EU
 
 
 class Num2Word_ES(Num2Word_EU):
+    CURRENCY_FORMS = {
+        'EUR': (('euro', 'euros'), ('centimo', 'centimos')),
+        'ESP': (('peseta', 'pesetas'), ('centimo', 'centimos')),
+    }
+
     # //CHECK: Is this sufficient??
     def set_high_numwords(self, high):
         max = 3 + 6 * len(high)
@@ -165,11 +172,12 @@ class Num2Word_ES(Num2Word_EU):
         self.verify_ordinal(value)
         return "%s%s" % (value, "º" if self.gender_stem == 'o' else "ª")
 
-    def to_currency(self, val, longval=True, old=False):
-        hightxt, lowtxt = "euro/s", "centavo/s"
+    def to_currency(self, val, currency='EUR', cents=True, seperator=' con',
+                    adjective=False, old=False):
         if old:
-            hightxt, lowtxt = "peso/s", "peseta/s"
-        result = self.to_splitnum(val, hightxt=hightxt, lowtxt=lowtxt,
-                                  divisor=1, jointxt="y", longval=longval)
+            currency = 'ESP'
+        result = super(Num2Word_ES, self).to_currency(
+            val, currency=currency, cents=cents, seperator=seperator,
+            adjective=adjective)
         # Handle exception, in spanish is "un euro" and not "uno euro"
         return result.replace("uno", "un")

--- a/tests/test_es.py
+++ b/tests/test_es.py
@@ -120,7 +120,7 @@ TEST_CASES_TO_CURRENCY = (
     (100.00, 'cien euros con cero centimos'),
 )
 
-TEST_CASES_TO_CURRENCY_OLD = (
+TEST_CASES_TO_CURRENCY_ESP = (
     (1.00, 'un peseta con cero centimos'),
     (2.00, 'dos pesetas con cero centimos'),
     (8.00, 'ocho pesetas con cero centimos'),
@@ -129,6 +129,17 @@ TEST_CASES_TO_CURRENCY_OLD = (
     (81.25, 'ochenta y un pesetas con veinticinco centimos'),
     (350.90, 'trescientos cincuenta pesetas con noventa centimos'),
     (100.00, 'cien pesetas con cero centimos'),
+)
+
+TEST_CASES_TO_CURRENCY_USD = (
+    (1.00, 'un dolar con cero centavos'),
+    (2.00, 'dos dolares con cero centavos'),
+    (8.00, 'ocho dolares con cero centavos'),
+    (12.00, 'doce dolares con cero centavos'),
+    (21.00, 'veintiun dolares con cero centavos'),
+    (81.25, 'ochenta y un dolares con veinticinco centavos'),
+    (350.90, 'trescientos cincuenta dolares con noventa centavos'),
+    (100.00, 'cien dolares con cero centavos'),
 )
 
 
@@ -159,9 +170,16 @@ class Num2WordsESTest(TestCase):
                 test[1]
             )
 
-    def test_currency_old(self):
-        for test in TEST_CASES_TO_CURRENCY_OLD:
+    def test_currency_esp(self):
+        for test in TEST_CASES_TO_CURRENCY_ESP:
             self.assertEqual(
-                num2words(test[0], lang='es', to='currency', old=True),
+                num2words(test[0], lang='es', to='currency', currency='ESP'),
+                test[1]
+            )
+
+    def test_currency_usd(self):
+        for test in TEST_CASES_TO_CURRENCY_USD:
+            self.assertEqual(
+                num2words(test[0], lang='es', to='currency', currency='USD'),
                 test[1]
             )

--- a/tests/test_es.py
+++ b/tests/test_es.py
@@ -110,23 +110,25 @@ TEST_CASES_ORDINAL_NUM = (
 )
 
 TEST_CASES_TO_CURRENCY = (
-    (1, 'un euro'),
-    (2, 'dos euros'),
-    (8, 'ocho euros'),
-    (12, 'doce euros'),
-    (21, 'veintiun euros'),
-    (81.25, 'ochenta y un euros y veinticinco centavos'),
-    (100, 'cien euros'),
+    (1.00, 'un euro con cero centimos'),
+    (2.00, 'dos euros con cero centimos'),
+    (8.00, 'ocho euros con cero centimos'),
+    (12.00, 'doce euros con cero centimos'),
+    (21.00, 'veintiun euros con cero centimos'),
+    (81.25, 'ochenta y un euros con veinticinco centimos'),
+    (350.90, 'trescientos cincuenta euros con noventa centimos'),
+    (100.00, 'cien euros con cero centimos'),
 )
 
 TEST_CASES_TO_CURRENCY_OLD = (
-    (1, 'un peso'),
-    (2, 'dos pesos'),
-    (8, 'ocho pesos'),
-    (12, 'doce pesos'),
-    (21, 'veintiun pesos'),
-    (81.25, 'ochenta y un pesos y veinticinco pesetas'),
-    (100, 'cien pesos'),
+    (1.00, 'un peseta con cero centimos'),
+    (2.00, 'dos pesetas con cero centimos'),
+    (8.00, 'ocho pesetas con cero centimos'),
+    (12.00, 'doce pesetas con cero centimos'),
+    (21.00, 'veintiun pesetas con cero centimos'),
+    (81.25, 'ochenta y un pesetas con veinticinco centimos'),
+    (350.90, 'trescientos cincuenta pesetas con noventa centimos'),
+    (100.00, 'cien pesetas con cero centimos'),
 )
 
 


### PR DESCRIPTION
## Fixes # by @Abranes (abraham@studio73.es)

### Changes proposed in this pull request:

* Update es_ES to new implementation of the to_currency()
* Change some spanish translations (in spanish 'cent' isn't 'centavos' is 'centimos' and the old currency is 'pesetas' not 'pesos')

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

`import num2words`
`a = 1234.01`
`print num2words.num2words(a, to='currency', lang='es_ES')`
`mil doscientos treinta y cuatro euros con un centimo`

### Additional notes

