### PR TITLE
[FIX] lang_LT, lang_LV: negative amounts

### DIFF
--- a/num2words/base.py
+++ b/num2words/base.py
@@ -89,6 +89,13 @@ class Num2Word_Base(object):
 
             return out
 
+    def parse_minus(self, num_str):
+        """Detach minus and return it as symbol with new num_str."""
+        if num_str.startswith('-'):
+            # Extra spacing to compensate if there is no minus.
+            return '%s ' % self.negword, num_str[1:]
+        return '', num_str
+
     def to_cardinal(self, value):
         try:
             assert int(value) == value

--- a/num2words/lang_LT.py
+++ b/num2words/lang_LT.py
@@ -14,6 +14,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 # MA 02110-1301 USA
+# TODO: replace WINDOWS line endings to UNIX?
 from __future__ import unicode_literals
 
 from .base import Num2Word_Base
@@ -98,15 +99,17 @@ class Num2Word_LT(Num2Word_Base):
 
     def to_cardinal(self, number):
         n = str(number).replace(',', '.')
+        base_str, n = self.parse_minus(n)
         if '.' in n:
             left, right = n.split('.')
-            return '%s %s %s' % (
+            return '%s%s %s %s' % (
+                base_str,
                 self._int2word(int(left)),
                 self.pointword,
                 self._int2word(int(right))
             )
         else:
-            return self._int2word(int(n))
+            return "%s%s" % (base_str, self._int2word(int(n)))
 
     def to_ordinal(self, number):
         raise NotImplementedError()

--- a/num2words/lang_LV.py
+++ b/num2words/lang_LV.py
@@ -14,6 +14,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 # MA 02110-1301 USA
+# TODO: replace WINDOWS line endings to UNIX?
 from __future__ import unicode_literals
 
 from .base import Num2Word_Base
@@ -132,15 +133,17 @@ class Num2Word_LV(Num2Word_Base):
 
     def to_cardinal(self, number):
         n = str(number).replace(',', '.')
+        base_str, n = self.parse_minus(n)
         if '.' in n:
             left, right = n.split('.')
-            return u'%s %s %s' % (
+            return '%s%s %s %s' % (
+                base_str,
                 self._int2word(int(left)),
                 self.pointword,
                 self._int2word(int(right))
             )
         else:
-            return self._int2word(int(n))
+            return "%s%s" % (base_str, self._int2word(int(n)))
 
     def pluralize(self, n, forms):
         form = 0 if (n % 10 == 1 and n % 100 != 11) else 1 if n != 0 else 2

--- a/tests/test_lt.py
+++ b/tests/test_lt.py
@@ -44,6 +44,14 @@ class Num2WordsLTTest(TestCase):
             "aštuoni šimtai dvidešimt du trilijonai aštuoni šimtai dvidešimt "
             "keturi milijardai trys šimtai aštuoniasdešimt keturi milijonai "
             "du šimtai dvidešimt tūkstančių du šimtai devyniasdešimt vienas")
+        self.assertEqual(
+            num2words(-5000, lang='lt'),
+            'minus penki tūkstančiai',
+        )
+        self.assertEqual(
+            num2words(-5000.22, lang='lt'),
+            'minus penki tūkstančiai kablelis dvidešimt du',
+        )
 
         # print(fill(n2w(1000000000000000000000000000000)))
         # naintilijonas

--- a/tests/test_lv.py
+++ b/tests/test_lv.py
@@ -39,6 +39,14 @@ class Num2WordsLVTest(TestCase):
             'divdesmit divi triljoni astoņi simti divdesmit četri '
             'miljardi trīs simti astoņdesmit četri miljoni divi simti '
             'divdesmit tūkstoši divi simti deviņdesmit viens')
+        self.assertEqual(
+            num2words(-5000, lang='lv'),
+            'mīnus pieci tūkstoši',
+        )
+        self.assertEqual(
+            num2words(-5000.22, lang='lv'),
+            'mīnus pieci tūkstoši komats divdesmit divi',
+        )
 
         # >>> print(fill(n2w(1000000000000000000000000000000)))
         # nontiljons


### PR DESCRIPTION
Negative amounts were not working (when no currency is used), because
`get_digits` method does not expect `-` sign, which crashes conversion.
To avoid that, we split minus sign from number string and prepare its
word to be used with amount words.

closes: #184

## Fixes # by...

### Changes proposed in this pull request:

Negative amounts for LT and LV conversion was not implemented and was crashing the conversion, so fix was committed (look for above for description).

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Unittests for LT and LV were added to verify this change that it works with negative amounts (when currency is not used).

