### PR TITLE
Add lang es_PE + tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,7 @@ Besides the numerical argument, there are two main optional arguments.
 * ``en_IN`` (English - India)
 * ``es`` (Spanish)
 * ``es_CO`` (Spanish - Colombia)
+* ``es_PE`` (Spanish - Perú)
 * ``es_VE`` (Spanish - Venezuela)
 * ``eu`` (EURO)
 * ``fi`` (Finnish)

--- a/num2words/__init__.py
+++ b/num2words/__init__.py
@@ -39,6 +39,7 @@ from . import lang_PT_BR
 from . import lang_HE
 from . import lang_IT
 from . import lang_ES_VE
+from . import lang_ES_PE
 from . import lang_ES_CO
 from . import lang_VN
 from . import lang_TR
@@ -60,6 +61,7 @@ CONVERTER_CLASSES = {
     'fi': lang_FI.Num2Word_FI(),
     'es': lang_ES.Num2Word_ES(),
     'es_CO': lang_ES_CO.Num2Word_ES_CO(),
+    'es_PE': lang_ES_PE.Num2Word_ES_PE(),
     'es_VE': lang_ES_VE.Num2Word_ES_VE(),
     'id': lang_ID.Num2Word_ID(),
     'ja': lang_JA.Num2Word_JA(),

--- a/num2words/lang_ES_PE.py
+++ b/num2words/lang_ES_PE.py
@@ -1,20 +1,39 @@
 # encoding: UTF-8
 
+# Copyright (c) 2003, Taro Ogawa.  All Rights Reserved.
+# Copyright (c) 2013, Savoir-faire Linux inc.  All Rights Reserved.
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301 USA
+
 from __future__ import print_function, unicode_literals
 
-from .lang_ES import Num2Word_ES
 from .currency import parse_currency_parts, prefix_currency
+from .lang_ES import Num2Word_ES
 
 
 class Num2Word_ES_PE(Num2Word_ES):
     CURRENCY_FORMS = {
         'PEN': (('sol', 'soles'), ('centimo', 'centimos')),
-        'USD': (('dolar americano', 'dolares americanos'), ('centimo', 'centimos'))
+        'USD': (
+            ('dolar americano', 'dolares americanos'), ('centimo', 'centimos'))
     }
 
-    def to_currency(self, val, currency='PEN', cents=True, seperator=' con', adjective=False):
-        left, right, is_negative = parse_currency_parts(val, is_int_with_cents=False)
-
+    def to_currency(self, val, currency='PEN', cents=True, seperator=' con',
+                    adjective=False):
+        left, right, is_negative = parse_currency_parts(val,
+                                                        is_int_with_cents=False
+                                                        )
         try:
             cr1, cr2 = self.CURRENCY_FORMS[currency]
 
@@ -30,7 +49,8 @@ class Num2Word_ES_PE(Num2Word_ES):
         if right > 0:
             cents_str = self._cents_verbose(right, currency) \
                 if cents else "%02d" % right
-            cents_str_currency = "%s %s %s" % (seperator, cents_str, self.pluralize(right, cr2))
+            cents_str_currency = "%s %s %s" % (
+                seperator, cents_str, self.pluralize(right, cr2))
         else:
             cents_str_currency = ""
 

--- a/num2words/lang_ES_PE.py
+++ b/num2words/lang_ES_PE.py
@@ -1,0 +1,45 @@
+# encoding: UTF-8
+
+from __future__ import print_function, unicode_literals
+
+from .lang_ES import Num2Word_ES
+from .currency import parse_currency_parts, prefix_currency
+
+
+class Num2Word_ES_PE(Num2Word_ES):
+    CURRENCY_FORMS = {
+        'PEN': (('sol', 'soles'), ('centimo', 'centimos')),
+        'USD': (('dolar americano', 'dolares americanos'), ('centimo', 'centimos'))
+    }
+
+    def to_currency(self, val, currency='PEN', cents=True, seperator=' con', adjective=False):
+        left, right, is_negative = parse_currency_parts(val, is_int_with_cents=False)
+
+        try:
+            cr1, cr2 = self.CURRENCY_FORMS[currency]
+
+        except KeyError:
+            raise NotImplementedError(
+                'Currency code "%s" not implemented for "%s"' %
+                (currency, self.__class__.__name__))
+
+        if adjective and currency in self.CURRENCY_ADJECTIVES:
+            cr1 = prefix_currency(self.CURRENCY_ADJECTIVES[currency], cr1)
+
+        minus_str = "%s " % self.negword if is_negative else ""
+        if right > 0:
+            cents_str = self._cents_verbose(right, currency) \
+                if cents else "%02d" % right
+            cents_str_currency = "%s %s %s" % (seperator, cents_str, self.pluralize(right, cr2))
+        else:
+            cents_str_currency = ""
+
+        result = u'%s%s %s%s' % (
+            minus_str,
+            self.to_cardinal(left),
+            self.pluralize(left, cr1),
+            cents_str_currency
+        )
+
+        # Handle exception, in spanish is "un sol" and not "uno sol"
+        return result.replace("uno", "un")

--- a/tests/test_es_pe.py
+++ b/tests/test_es_pe.py
@@ -1,0 +1,47 @@
+# encoding: UTF-8
+
+from __future__ import unicode_literals
+
+from num2words import num2words
+
+from . import test_es
+
+TEST_CASES_TO_CURRENCY = (
+    (1, 'un sol'),
+    (2, 'dos soles'),
+    (8, 'ocho soles'),
+    (12, 'doce soles'),
+    (21, 'veintiun soles'),
+    (81.25, 'ochenta y un soles con veinticinco centimos'),
+    (81.01, 'ochenta y un soles con un centimo'),
+    (81.1, 'ochenta y un soles con diez centimos'),
+    (100, 'cien soles'),
+)
+
+
+class Num2WordsESPETest(test_es.Num2WordsESTest):
+
+    def test_number(self):
+        for test in test_es.TEST_CASES_CARDINAL:
+            self.assertEqual(num2words(test[0], lang='es_PE'), test[1])
+
+    def test_ordinal(self):
+        for test in test_es.TEST_CASES_ORDINAL:
+            self.assertEqual(
+                num2words(test[0], lang='es_PE', ordinal=True),
+                test[1]
+            )
+
+    def test_ordinal_num(self):
+        for test in test_es.TEST_CASES_ORDINAL_NUM:
+            self.assertEqual(
+                num2words(test[0], lang='es', to='ordinal_num'),
+                test[1]
+            )
+
+    def test_currency(self):
+        for test in TEST_CASES_TO_CURRENCY:
+            self.assertEqual(
+                num2words(test[0], lang='es_PE', to='currency'),
+                test[1]
+            )


### PR DESCRIPTION
## Changes proposed in this pull request:


* Added support for es_PE (Spanish Perú) currency (PEN)
* include test and readme

### Status

- [X ] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

```
from num2words import num2words
num2words(1234.56, to='currency', lang='es_PE')
```

### Additional notes

* I have overwritten the to_currency method in line 280 of base.py adding the parameter
`is_int_with_cents = False`

* I changed the rendering format in my country when the cents is 0 is not written

