### PR TITLE
[FIX] lang_FR: Fixed decimal handling in french currency

### DIFF
--- a/num2words/lang_FR.py
+++ b/num2words/lang_FR.py
@@ -96,5 +96,6 @@ class Num2Word_FR(Num2Word_EU):
         hightxt = "euro/s"
         if old:
             hightxt = "franc/s"
-        return self.to_splitnum(val, hightxt=hightxt, lowtxt="centime/s",
-                                divisor=1, jointxt="et", longval=longval)
+        cents = int(round(val*100))
+        return self.to_splitnum(cents, hightxt=hightxt, lowtxt="centime/s",
+                                divisor=100, jointxt="et", longval=longval)

--- a/tests/test_fr.py
+++ b/tests/test_fr.py
@@ -122,6 +122,7 @@ TEST_CASES_TO_CURRENCY = (
     (12, 'douze euros'),
     (21, 'vingt et un euros'),
     (81.25, 'quatre-vingt-un euros et vingt-cinq centimes'),
+    (81.2, 'quatre-vingt-un euros et vingt centimes'),
     (100, 'cent euros'),
 )
 
@@ -132,6 +133,7 @@ TEST_CASES_TO_CURRENCY_OLD = (
     (12, 'douze francs'),
     (21, 'vingt et un francs'),
     (81.25, 'quatre-vingt-un francs et vingt-cinq centimes'),
+    (81.2, 'quatre-vingt-un francs et vingt centimes'),
     (100, 'cent francs'),
 )
 


### PR DESCRIPTION
## Fixes #179 by CrazyMerlyn

### Changes proposed in this pull request:

* `num2words(1.5, lang='fr', to='currency')` now returns `'un euro et cinquante centimes'` instead of `'un euro et cinq centimes'`

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

`num2words(1.5, lang='fr', to='currency')`