### PR TITLE
add currency PEN

### DIFF
--- a/num2words/lang_ES.py
+++ b/num2words/lang_ES.py
@@ -26,6 +26,7 @@ class Num2Word_ES(Num2Word_EU):
         'EUR': (('euro', 'euros'), ('centimo', 'centimos')),
         'ESP': (('peseta', 'pesetas'), ('centimo', 'centimos')),
         'USD': (('dolar', 'dolares'), ('centavo', 'centavos')),
+        'PEN': (('sol', 'soles'), ('centimo', 'centimos')),
     }
 
     # //CHECK: Is this sufficient??

--- a/tests/test_es.py
+++ b/tests/test_es.py
@@ -142,6 +142,17 @@ TEST_CASES_TO_CURRENCY_USD = (
     (100.00, 'cien dolares con cero centavos'),
 )
 
+TEST_CASES_TO_CURRENCY_PEN = (
+    (1.00, 'un sol con cero centimos'),
+    (2.00, 'dos soles con cero centimos'),
+    (8.00, 'ocho soles con cero centimos'),
+    (12.00, 'doce soles con cero centimos'),
+    (21.00, 'veintiun soles con cero centimos'),
+    (81.25, 'ochenta y un soles con veinticinco centimos'),
+    (350.90, 'trescientos cincuenta soles con noventa centimos'),
+    (100.00, 'cien soles con cero centimos'),
+)
+
 
 class Num2WordsESTest(TestCase):
 
@@ -181,5 +192,12 @@ class Num2WordsESTest(TestCase):
         for test in TEST_CASES_TO_CURRENCY_USD:
             self.assertEqual(
                 num2words(test[0], lang='es', to='currency', currency='USD'),
+                test[1]
+            )
+
+    def test_currency_pen(self):
+        for test in TEST_CASES_TO_CURRENCY_PEN:
+            self.assertEqual(
+                num2words(test[0], lang='es', to='currency', currency='PEN'),
                 test[1]
             )


### PR DESCRIPTION
add currency PEN in es lang

### Changes proposed in this pull request:

* add PEN currency (soles, centimos)

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

```
num2words(42.5, lang='es', to='currency', currency='PEN')
cuarenta y dos soles con cincuenta céntimos
```
