### PR TITLE
added more tests to lang_DE.py

### DIFF
--- a/num2words/lang_DE.py
+++ b/num2words/lang_DE.py
@@ -117,13 +117,17 @@ class Num2Word_DE(Num2Word_EU):
         return str(value) + "."
 
     def to_currency(self, val, longval=True, old=False):
+        hightxt = "euro"
+        lowtxt = "cent"
         if old:
-            return self.to_splitnum(val, hightxt="mark/s", lowtxt="pfennig/e",
-                                    jointxt="und", longval=longval)
-        return super(Num2Word_DE, self).to_currency(val, jointxt="und",
-                                                    longval=longval)
+            hightxt = "mark"
+            lowtxt = "pfennig/e"
+
+        return self.to_splitnum(val, hightxt=hightxt, lowtxt=lowtxt,
+                                jointxt="und", longval=longval)
 
     def to_year(self, val, longval=True):
         if not (val // 100) % 10:
             return self.to_cardinal(val)
-        return self.to_splitnum(val, hightxt="hundert", longval=longval)
+        return self.to_splitnum(val, hightxt="hundert", longval=longval)\
+            .replace(' ', '')

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -68,13 +68,17 @@ class Num2WordsDETest(TestCase):
         self.assertRaises(TypeError, num2words, 2.453, ordinal=True, lang='de')
 
     def test_currency(self):
-        self.assertEqual(num2words(12.00, to='currency', lang='de'), 'zwölf euro')
+        self.assertEqual(num2words(12.00, to='currency', lang='de'),
+                         'zwölf euro')
 
     def test_old_currency(self):
-        self.assertEqual(num2words(12.00, to='currency', lang='de', old=True), 'zwölf mark')
+        self.assertEqual(num2words(12.00, to='currency', lang='de', old=True),
+                         'zwölf mark')
 
     def test_year(self):
-        self.assertEqual(num2words(2002, to='year', lang='de'), 'zweitausendzwei')
+        self.assertEqual(num2words(2002, to='year', lang='de'),
+                         'zweitausendzwei')
 
     def test_year_before_2000(self):
-        self.assertEqual(num2words(1780, to='year', lang='de'), 'siebzehnhundertachtzig')
+        self.assertEqual(num2words(1780, to='year', lang='de'),
+                         'siebzehnhundertachtzig')

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -54,6 +54,7 @@ class Num2WordsDETest(TestCase):
     def test_cardinal_at_some_numbers(self):
         self.assertEqual(num2words(2000000, lang='de'), "zwei millionen")
         self.assertEqual(num2words(4000000000, lang='de'), "vier milliarden")
+        self.assertEqual(num2words(1000000000, lang='de'), "eine milliarde")
 
     def test_cardinal_for_decimal_number(self):
         self.assertEqual(
@@ -65,3 +66,15 @@ class Num2WordsDETest(TestCase):
 
     def test_ordinal_for_floating_numbers(self):
         self.assertRaises(TypeError, num2words, 2.453, ordinal=True, lang='de')
+
+    def test_currency(self):
+        self.assertEqual(num2words(12.00, to='currency', lang='de'), 'zwölf euro')
+
+    def test_old_currency(self):
+        self.assertEqual(num2words(12.00, to='currency', lang='de', old=True), 'zwölf mark')
+
+    def test_year(self):
+        self.assertEqual(num2words(2002, to='year', lang='de'), 'zweitausendzwei')
+
+    def test_year_before_2000(self):
+        self.assertEqual(num2words(1780, to='year', lang='de'), 'siebzehnhundertachtzig')


### PR DESCRIPTION
## More tests according to #120 

### Changes proposed in this pull request:

* Added more test to tests/test_de.py for lang_DE.py

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Running coverage tools should indicate a higher coverage on lang_DE.py

### Additional notes

These changes also unveil a few (probably unknown) inconsistencies regarding num2years in german:
Before the year 2000 the years have a lot of spaces in them, while afterwards they are one word.

