### PR TITLE
fixed currency / year for lang_DE

### DIFF
--- a/num2words/lang_DE.py
+++ b/num2words/lang_DE.py
@@ -117,13 +117,17 @@ class Num2Word_DE(Num2Word_EU):
         return str(value) + "."
 
     def to_currency(self, val, longval=True, old=False):
+        hightxt = "euro"
+        lowtxt = "cent"
         if old:
-            return self.to_splitnum(val, hightxt="mark/s", lowtxt="pfennig/e",
-                                    jointxt="und", longval=longval)
-        return super(Num2Word_DE, self).to_currency(val, jointxt="und",
-                                                    longval=longval)
+            hightxt = "mark"
+            lowtxt = "pfennig/e"
+
+        return self.to_splitnum(val, hightxt=hightxt, lowtxt=lowtxt,
+                                jointxt="und", longval=longval)
 
     def to_year(self, val, longval=True):
         if not (val // 100) % 10:
             return self.to_cardinal(val)
-        return self.to_splitnum(val, hightxt="hundert", longval=longval)
+        return self.to_splitnum(val, hightxt="hundert", longval=longval)\
+            .replace(' ', '')


### PR DESCRIPTION
## Fixes issues found in #201 

### Changes proposed in this pull request:

* all changes concern `num2words/lang_DE.py`
* remove inconsistent spacing in to_year for pre/post Y2k years
* fix incorrect plurals of to_currency

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

The tests found added in #201 should now pass.

### Additional notes

 - 

