### PR TITLE
Added more robust checks and cases to string inputs (including handing decimal and thousand/million/billion/etc separators)

### DIFF
--- a/num2words/lang_EN.py
+++ b/num2words/lang_EN.py
@@ -49,6 +49,13 @@ class Num2Word_EN(lang_EU.Num2Word_EU):
                      "nine": "ninth",
                      "twelve": "twelfth"}
 
+    # Switch separators to ',' (thousands) and '.' (decimals)
+    def to_cardinal(self, value):
+        return super(Num2Word_EN, self).to_cardinal(value, thousand_separator=',', decimal_separator='.')
+
+    def to_cardinal_float(self, value):
+        return super(Num2Word_EN, self).to_cardinal_float(value, thousand_separator=',', decimal_separator='.')
+
     def merge(self, lpair, rpair):
         ltext, lnum = lpair
         rtext, rnum = rpair


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

* Handle string valued inputs more robustly
* Integers represented as strings no longer default to floats
* For EU / base language cases, treat ',' as decimal and '.' for thousand / million / etc places
* For EN, switch to '.' and ',' for corresponding separators

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* Various tests (taking '.' as decimal place here):
```
>>> from num2words import num2words
>>> num2words(8)
'eight'
>>> num2words('8')
'eight'
>>> num2words('8.8')
'eight point eight'
>>> num2words('8000000.8')
'eight million point eight'
>>> num2words('8,000,000.8')
'eight million point eight'
>>> num2words('8000,000.8')
TypeError: Incorrectly formatted number: 8000,000.8
>>> num2words('8,0000,00.8')
TypeError: Incorrectly formatted number: 8,0000,00.8
>>> num2words('8,000,.8')
TypeError: Incorrectly formatted number: 8,000,.8
>>> num2words('8.000,8')
TypeError: Decimal place before thousand separator: 8.000,8
>>> num2words('8.000.8')
TypeError: Multiple decimal places: 8.000.8
```

### Additional notes

* Saw an issue where string input defaulted to floats, and in general there wasn't much string handling