### PR TITLE
Add Delegator.py to test dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,5 +56,6 @@ setup(
     test_suite='tests',
     classifiers=CLASSIFIERS,
     scripts=['bin/num2words'],
-    install_requires=["docopt>=0.6.2"]
+    install_requires=["docopt>=0.6.2"],
+    tests_require=['delegator.py'],
 )


### PR DESCRIPTION
Delegator.py is used for cli tests but isn't included in dependencies.

## Fixes # by...
Fixes install workflow by making testing dependencies explicit.

### Changes proposed in this pull request:
* Add delegator.py to test dependencies

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change
Error given when delegator.py not installed, expected behavior (delegator.py installed auomatically) with patch.
pip uninstall delegator.py
python setup.py tests

Resulting stack trace

> ImportError: Failed to import test module: test_cli
> Traceback (most recent call last):
>   File "/usr/lib/python3.6/unittest/loader.py", line 153, in loadTestsFromName
>     module = \_\_import\_\_(module_name)
>   File "/home/ben/code/num2words/tests/test_cli.py", line 9, in <module>
>     import delegator
> ModuleNotFoundError: No module named 'delegator'
> 