### PR TITLE
Correction of german ordinals.

### DIFF
--- a/num2words/lang_DE.py
+++ b/num2words/lang_DE.py
@@ -70,9 +70,9 @@ class Num2Word_DE(Num2Word_EU):
                      "ert": "erts",
                      "end": "ends",
                      "ion": "ions",
-                     "nen": "nens",
-                     "rde": "rdes",
-                     "rden": "rdens"}
+                     "nen": "ns",
+                     "rde": "rds",
+                     "rden": "rds"}
 
     def merge(self, curr, next):
         ctext, cnum, ntext, nnum = curr + next

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -44,11 +44,11 @@ class Num2WordsDETest(TestCase):
             num2words(4000, ordinal=True, lang='de'), "viertausendste"
         )
         self.assertEqual(
-            num2words(2000000, ordinal=True, lang='de'), "zwei millionenste"
+            num2words(2000000, ordinal=True, lang='de'), "zwei millionste"
         )
         self.assertEqual(
             num2words(5000000000, ordinal=True, lang='de'),
-            "fünf milliardenste"
+            "fünf milliardste"
         )
 
     def test_cardinal_at_some_numbers(self):


### PR DESCRIPTION
The ordinals for very big numbers (million and up) were incorrect.

For the german speakers:
Incorrect (old): Millionenste / Billiardenste
Correct (new): Millionste / Billardste