### PR TITLE
Refactor testing setup

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,5 @@
 [run]
 branch = true
-source = num2words
+source =
+    num2words
+    tests

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,3 @@
-[report]
-omit =
-    */.tox/*
-    */tests/*
+[run]
+branch = true
+source = num2words

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,16 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-install: pip install tox-travis
+matrix:
+  include:
+    - { python: 3.6, env: TOXENV=flake8 }
+    - { python: 3.6, env: TOXENV=isort }
+    # Py37 requires xenial distrubution and sudo
+    # See travis-ci/travis-ci#9069
+    - { python: 3.7, dist: xenial, sudo: true }
+
+install:
+  - pip install tox-travis
+  - pip install coveralls
 script: tox
+after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ install:
   - pip install tox-travis
   - pip install coveralls
 script: tox
-after_success: coveralls
+after_success: if [ -e .coverage ]; then coveralls; fi

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,11 @@ The test suite in this library is new, so it's rather thin, but it can be run wi
 
     python setup.py test
 
+To run the full CI test suite which includes linting and multiple python environments::
+
+    pip install tox
+    tox
+
 Usage
 -----
 Command line::

--- a/num2words/lang_PT.py
+++ b/num2words/lang_PT.py
@@ -157,7 +157,7 @@ class Num2Word_PT(Num2Word_EU):
         for ext in (
                 'mil', 'milhão', 'milhões', 'mil milhões',
                 'bilião', 'biliões', 'mil biliões'):
-            if re.match('.*{} e \w*entos? (?=.*e)'.format(ext), result):
+            if re.match('.*{} e \\w*entos? (?=.*e)'.format(ext), result):
                 result = result.replace(
                     '{} e'.format(ext), '{}'.format(ext)
                 )
@@ -195,7 +195,7 @@ class Num2Word_PT(Num2Word_EU):
 
         result = ' '.join(result[::-1])
         result = result.strip()
-        result = re.sub('\s+', ' ', result)
+        result = re.sub('\\s+', ' ', result)
 
         if result.startswith('primeiro') and value != '1':
             # avoiding "primeiro milésimo", "primeiro milionésimo" and so on

--- a/num2words/lang_PT_BR.py
+++ b/num2words/lang_PT_BR.py
@@ -79,7 +79,7 @@ class Num2Word_PT_BR(lang_PT.Num2Word_PT):
         for ext in (
                 'mil', 'milhão', 'milhões', 'bilhão', 'bilhões',
                 'trilhão', 'trilhões', 'quatrilhão', 'quatrilhões'):
-            if re.match('.*{} e \w*ento'.format(ext), result):
+            if re.match('.*{} e \\w*ento'.format(ext), result):
                 result = result.replace(
                     '{} e'.format(ext), '{},'.format(ext), 1
                 )

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,5 +3,4 @@ flake8-copyright
 isort
 pep8<1.6
 coverage
-coveralls
 delegator.py

--- a/tests/test_fi.py
+++ b/tests/test_fi.py
@@ -16,7 +16,6 @@
 
 from __future__ import division, print_function, unicode_literals
 
-import sys
 from unittest import TestCase
 
 from num2words import num2words
@@ -30,50 +29,6 @@ CASES = ["nominative", "genitive", "partitive",    # grammatical
 
 def n2f(*args, **kwargs):
     return num2words(lang='fi', *args, **kwargs)
-
-
-def create_test(number, to):
-    return (
-        "# %s\n" % num2words(number, lang='en') +
-        "self.assertEqual(\n" +
-        '    tuple(n2f(%s, to="%s", case=c) for c in CASES),\n' %
-        (number, to) +
-        # grammatical
-        '    ("%s", "%s", "%s",\n' %
-        tuple(n2f(number, to=to, case=c) for c in CASES[0:3]) +
-        # internal locative
-        '     "%s", "%s", "%s",\n' %
-        tuple(n2f(number, to=to, case=c) for c in CASES[3:6]) +
-        # external locative
-        '     "%s", "%s", "%s",\n' %
-        tuple(n2f(number, to=to, case=c) for c in CASES[6:9]) +
-        # essive
-        '     "%s", "%s",\n' %
-        tuple(n2f(number, to=to, case=c) for c in CASES[9:11]) +
-        # rare
-        '     "%s", "%s", "%s")\n' %
-        tuple(n2f(number, to=to, case=c) for c in CASES[11:14]) +
-        ")\n" +
-        "self.assertEqual(\n" +
-        '    tuple(n2f(%s, to="%s", case=c, plural=True) for c in CASES),\n' %
-        (number, to) +
-        # grammatical
-        '    ("%s", "%s", "%s",\n' %
-        tuple(n2f(number, to=to, case=c, plural=True) for c in CASES[0:3]) +
-        # internal locative
-        '     "%s", "%s", "%s",\n' %
-        tuple(n2f(number, to=to, case=c, plural=True) for c in CASES[3:6]) +
-        # external locative
-        '     "%s", "%s", "%s",\n' %
-        tuple(n2f(number, to=to, case=c, plural=True) for c in CASES[6:9]) +
-        # essive
-        '     "%s", "%s",\n' %
-        tuple(n2f(number, to=to, case=c, plural=True) for c in CASES[9:11]) +
-        # rare
-        '     "%s", "%s", "%s")\n' %
-        tuple(n2f(number, to=to, case=c, plural=True) for c in CASES[11:14]) +
-        ")\n"
-    )
 
 
 class Num2WordsFITest(TestCase):
@@ -2804,7 +2759,3 @@ class Num2WordsFITest(TestCase):
         self.assertEqual(
             n2f(150, to="currency", currency="FIM", adjective=True),
             "yksi Suomen markka ja viisikymmentä penniä")
-
-
-if __name__ == '__main__':
-    print(create_test(int(sys.argv[1]), sys.argv[2]))

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
 commands =
     coverage run -m unittest discover
     coverage report --fail-under=75 --omit=.tox/*,tests/*,/usr/*
+    coverage report --fail-under=100 --include=tests/* --skip-covered
 
 [testenv:flake8]
 changedir = {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,22 @@
 [tox]
-envlist = flake8,isort,py27,py34,py35,py36
+envlist = py27,py3{4,5,6,7},flake8,isort
 
 [testenv]
 passenv = TRAVIS TRAVIS_*
 deps =
     -r{toxinidir}/requirements-test.txt
 commands =
-    flake8
-    isort --check-only --recursive --diff num2words tests
     coverage erase
     coverage run -m unittest discover
     coverage report --fail-under=75 --omit=.tox/*,tests/*,/usr/*
-    coveralls
+
+[testenv:flake8]
+changedir = {toxinidir}
+commands =
+    flake8
+
+[testenv:isort]
+changedir = {toxinidir}
+commands =
+    isort --check-only --recursive --diff num2words tests
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,27 @@
 [tox]
-envlist = py27,py3{4,5,6,7},flake8,isort
+envlist = flake8,isort,py27,py34,py35,py36,py37
 
 [testenv]
 passenv = TRAVIS TRAVIS_*
 deps =
-    -r{toxinidir}/requirements-test.txt
+    coverage
+    delegator.py
 commands =
-    coverage erase
     coverage run -m unittest discover
     coverage report --fail-under=75 --omit=.tox/*,tests/*,/usr/*
 
 [testenv:flake8]
 changedir = {toxinidir}
+deps =
+    flake8
+    flake8-copyright
 commands =
     flake8
 
 [testenv:isort]
 changedir = {toxinidir}
+deps =
+    isort
+    delegator.py
 commands =
     isort --check-only --recursive --diff num2words tests
-


### PR DESCRIPTION
### Changes proposed in this pull request:
Overall goals were to only runs flake8 and isort once (via tox or travis), increase breadth of coverage information (branching and tests run), and add Python 3.7 testing.

* Include branch coverage in coverage reports
* Run coverage against tests and main package, ignoring other directories
* Add Flake8 and isort sections to run only once (under CPython 3.6)
* Add CPython 3.7 to testing matrix (requires Xenial with sudo)
* Only submit coverage statistics if results file exists (specifically to exclude flake8 and isort)
* Remove unused test generation code from test_fi.py
* Add python3.7 to tox execution list
* Move flake8 and isort into separate execution sections for tox
* Include specific dependencies for each testenv
* Add coverage report requiring 100% coverage of test code to ensure all tests are run

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Additional coverage data at coveralls appears at [Coveralls.io](https://coveralls.io/github/btharper/num2words)
Travis job list is visible at [Travis-ci.org](https://travis-ci.org/btharper/num2words)

### Additional notes

Submitting PR to confirm utility of changes. If this line of changes are useful I can also include more documentation surrounding how/why everything is being run and how to use it locally.