### PR TITLE
Convert strings to Decimal values

### DIFF
--- a/num2words/__init__.py
+++ b/num2words/__init__.py
@@ -96,6 +96,8 @@ def num2words(number, ordinal=False, lang='en', to='cardinal', **kwargs):
     if lang not in CONVERTER_CLASSES:
         raise NotImplementedError()
     converter = CONVERTER_CLASSES[lang]
+    if isinstance(number, str):
+        number = converter.str_to_number(number)
     # backwards compatible
     if ordinal:
         return converter.to_ordinal(number)

--- a/num2words/base.py
+++ b/num2words/base.py
@@ -96,6 +96,9 @@ class Num2Word_Base(object):
             return '%s ' % self.negword, num_str[1:]
         return '', num_str
 
+    def str_to_number(self, value):
+        return Decimal(value)
+
     def to_cardinal(self, value):
         try:
             assert int(value) == value

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,7 +72,7 @@ class CliTestCase(unittest.TestCase):
         self.assertEqual(output.return_code, 0)
         self.assertEqual(
             output.out.strip(),
-            "one hundred and fifty point zero"
+            "one hundred and fifty"
         )
 
     def test_cli_with_lang(self):
@@ -82,7 +82,7 @@ class CliTestCase(unittest.TestCase):
         self.assertEqual(output.return_code, 0)
         self.assertEqual(
             output.out.strip(),
-            "ciento cincuenta punto cero"
+            "ciento cincuenta"
         )
 
     def test_cli_with_lang_to(self):


### PR DESCRIPTION
## Fixes #182 by coercing strings into numeric objects

### Changes proposed in this pull request:

* Punt string handling to python Decimal object, this correctly represents both integers and floats (except with regards to trailing zeros)
  * num2words('1.00') == 'one' instead of 'one point zero zero'
* Change command line tests to reflect handling of ints

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change
"bin/num2words 1" yields 'one' instead of 'one point zero'
all((num2words(i) == num2words(str(i)) for i in range(1000))) == True
### Additional notes
String to Decimal conversion is available in the language converter object, I'm unsure if this will ever need to be adapted per language, and it seems ill-advised to guess based on current or target locale/language.
Python >= 3.5 can use underscores as thousands separators in strings i.e. num2words('3_000') = 'three thousand'