### PR TITLE
Extend Polish names + typos; power of thousand names not inserted when value is 0

### DIFF
--- a/num2words/lang_CZ.py
+++ b/num2words/lang_CZ.py
@@ -130,6 +130,10 @@ class Num2Word_CZ(Num2Word_Base):
         i = len(chunks)
         for x in chunks:
             i -= 1
+
+            if x == 0:
+                continue
+
             n1, n2, n3 = get_digits(x)
 
             if n3 > 0:
@@ -143,7 +147,7 @@ class Num2Word_CZ(Num2Word_Base):
             elif n1 > 0 and not (i > 0 and x == 1):
                 words.append(ONES[n1][0])
 
-            if x > 0 and i > 0:
+            if i > 0:
                 words.append(self.pluralize(x, THOUSANDS[i]))
 
         return ' '.join(words)

--- a/num2words/lang_CZ.py
+++ b/num2words/lang_CZ.py
@@ -143,7 +143,7 @@ class Num2Word_CZ(Num2Word_Base):
             elif n1 > 0 and not (i > 0 and x == 1):
                 words.append(ONES[n1][0])
 
-            if i > 0:
+            if x > 0 and i > 0:
                 words.append(self.pluralize(x, THOUSANDS[i]))
 
         return ' '.join(words)

--- a/num2words/lang_HE.py
+++ b/num2words/lang_HE.py
@@ -94,9 +94,11 @@ def int2word(n):
     i = len(chunks)
     for x in chunks:
         i -= 1
-        n1, n2, n3 = get_digits(x)
 
-        # print str(n3) + str(n2) + str(n1)
+        if x == 0:
+            continue
+
+        n1, n2, n3 = get_digits(x)
 
         if n3 > 0:
             if n3 <= 2:
@@ -113,7 +115,7 @@ def int2word(n):
         elif n1 > 0 and not (i > 0 and x == 1):
             words.append(ONES[n1][0])
 
-        if x > 0 and i > 0:
+        if i > 0:
             if i <= 2:
                 words.append(THOUSANDS[i][0])
             else:

--- a/num2words/lang_HE.py
+++ b/num2words/lang_HE.py
@@ -113,7 +113,7 @@ def int2word(n):
         elif n1 > 0 and not (i > 0 and x == 1):
             words.append(ONES[n1][0])
 
-        if i > 0:
+        if x > 0 and i > 0:
             if i <= 2:
                 words.append(THOUSANDS[i][0])
             else:

--- a/num2words/lang_LT.py
+++ b/num2words/lang_LT.py
@@ -169,7 +169,7 @@ class Num2Word_LT(Num2Word_Base):
                 else:
                     words.append(ONES[n1][0])
 
-            if i > 0:
+            if x > 0 and i > 0:
                 words.append(self.pluralize(x, THOUSANDS[i]))
 
         return ' '.join(words)

--- a/num2words/lang_LT.py
+++ b/num2words/lang_LT.py
@@ -149,6 +149,10 @@ class Num2Word_LT(Num2Word_Base):
 
         for x in chunks:
             i -= 1
+
+            if x == 0:
+                continue
+
             n1, n2, n3 = get_digits(x)
 
             if n3 > 0:
@@ -169,7 +173,7 @@ class Num2Word_LT(Num2Word_Base):
                 else:
                     words.append(ONES[n1][0])
 
-            if x > 0 and i > 0:
+            if i > 0:
                 words.append(self.pluralize(x, THOUSANDS[i]))
 
         return ' '.join(words)

--- a/num2words/lang_LV.py
+++ b/num2words/lang_LV.py
@@ -176,7 +176,7 @@ class Num2Word_LV(Num2Word_Base):
             elif n1 > 0 and not (i > 0 and x == 1):
                 words.append(ONES[n1][0])
 
-            if i > 0 and x != 0:
+            if x > 0 and i > 0:
                 words.append(self.pluralize(x, THOUSANDS[i]))
 
         return ' '.join(words)

--- a/num2words/lang_LV.py
+++ b/num2words/lang_LV.py
@@ -157,6 +157,10 @@ class Num2Word_LV(Num2Word_Base):
         i = len(chunks)
         for x in chunks:
             i -= 1
+
+            if x == 0:
+                continue
+
             n1, n2, n3 = get_digits(x)
 
             if n3 > 0:
@@ -176,7 +180,7 @@ class Num2Word_LV(Num2Word_Base):
             elif n1 > 0 and not (i > 0 and x == 1):
                 words.append(ONES[n1][0])
 
-            if x > 0 and i > 0:
+            if i > 0:
                 words.append(self.pluralize(x, THOUSANDS[i]))
 
         return ' '.join(words)

--- a/num2words/lang_PL.py
+++ b/num2words/lang_PL.py
@@ -70,16 +70,27 @@ HUNDREDS = {
 }
 
 THOUSANDS = {
-    1: ('tysiąc', 'tysiące', 'tysięcy'),  # 10^3
-    2: ('milion', 'miliony', 'milionów'),  # 10^6
-    3: ('miliard', 'miliardy', 'miliardów'),  # 10^9
-    4: ('bilion', 'biliony', 'bilionów'),  # 10^12
-    5: ('biliard', 'biliardy', 'biliardów'),  # 10^15
-    6: ('trylion', 'tryliony', 'trylionów'),  # 10^18
-    7: ('tryliard', 'tryliardy', 'tryliardów'),  # 10^21
-    8: ('kwadrylion', 'kwadryliony', 'kwadrylionów'),  # 10^24
-    9: ('kwaryliard', 'kwadryliardy', 'kwadryliardów'),  # 10^27
-    10: ('kwintylion', 'kwintyliony', 'kwintylionów'),  # 10^30
+    1: ('tysiąc',       'tysiące',      'tysięcy'),       # 10^3
+    2: ('milion',       'miliony',      'milionów'),      # 10^6
+    3: ('miliard',      'miliardy',     'miliardów'),     # 10^9
+    4: ('bilion',       'biliony',      'bilionów'),      # 10^12
+    5: ('biliard',      'biliardy',     'biliardów'),     # 10^15
+    6: ('trylion',      'tryliony',     'trylionów'),     # 10^18
+    7: ('tryliard',     'tryliardy',    'tryliardów'),    # 10^21
+    8: ('kwadrylion',   'kwadryliony',  'kwadrylionów'),  # 10^24
+    9: ('kwadryliard',  'kwadryliardy', 'kwadryliardów'), # 10^27
+    10: ('kwintylion',  'kwintyliony',  'kwintylionów'),  # 10^30
+    11: ('kwintyliard', 'kwintyliardy', 'kwintyliardów'), # 10^33
+    12: ('sekstylion',  'sekstyliony',  'sekstylionów'),  # 10^36
+    13: ('sekstyliard', 'sekstyliardy', 'sekstyliardów'), # 10^39
+    14: ('septylion',   'septyliony',   'septylionów'),   # 10^42
+    15: ('septyliard',  'septyliardy',  'septyliardów'),  # 10^45
+    16: ('oktylion',    'oktyliony',    'oktylionów'),    # 10^48
+    17: ('oktyliard',   'oktyliardy',   'oktyliardów'),   # 10^51
+    18: ('nonylion',    'nonyliony',    'nonylionów'),    # 10^54
+    19: ('nonyliard',   'nonyliardy',   'nonyliardów'),   # 10^57
+    20: ('decylion',    'decyliony',    'decylionów'),    # 10^60
+    21: ('decyliard',   'decyliardy',   'decyliardów'),   # 10^63
 }
 
 
@@ -92,11 +103,11 @@ class Num2Word_PL(Num2Word_Base):
             ('euro', 'euro', 'euro'), ('cent', 'centy', 'centów')
         ),
     }
-
+    
     def setup(self):
         self.negword = "minus"
         self.pointword = "przecinek"
-
+    
     def to_cardinal(self, number):
         n = str(number).replace(',', '.')
         if '.' in n:
@@ -108,7 +119,7 @@ class Num2Word_PL(Num2Word_Base):
             )
         else:
             return self._int2word(int(n))
-
+    
     def pluralize(self, n, forms):
         if n == 1:
             form = 0
@@ -117,33 +128,33 @@ class Num2Word_PL(Num2Word_Base):
         else:
             form = 2
         return forms[form]
-
+    
     def to_ordinal(self, number):
         raise NotImplementedError()
-
+    
     def _int2word(self, n):
         if n == 0:
             return ZERO[0]
-
+        
         words = []
         chunks = list(splitbyx(str(n), 3))
         i = len(chunks)
         for x in chunks:
             i -= 1
             n1, n2, n3 = get_digits(x)
-
+            
             if n3 > 0:
                 words.append(HUNDREDS[n3][0])
-
+            
             if n2 > 1:
                 words.append(TWENTIES[n2][0])
-
+            
             if n2 == 1:
                 words.append(TENS[n1][0])
             elif n1 > 0 and not (i > 0 and x == 1):
                 words.append(ONES[n1][0])
-
+            
             if i > 0:
                 words.append(self.pluralize(x, THOUSANDS[i]))
-
+        
         return ' '.join(words)

--- a/num2words/lang_PL.py
+++ b/num2words/lang_PL.py
@@ -154,7 +154,7 @@ class Num2Word_PL(Num2Word_Base):
             elif n1 > 0 and not (i > 0 and x == 1):
                 words.append(ONES[n1][0])
 
-            if i > 0:
+            if x > 0 and i > 0:
                 words.append(self.pluralize(x, THOUSANDS[i]))
 
         return ' '.join(words)

--- a/num2words/lang_PL.py
+++ b/num2words/lang_PL.py
@@ -141,6 +141,10 @@ class Num2Word_PL(Num2Word_Base):
         i = len(chunks)
         for x in chunks:
             i -= 1
+
+            if x == 0:
+                continue
+
             n1, n2, n3 = get_digits(x)
 
             if n3 > 0:
@@ -154,7 +158,7 @@ class Num2Word_PL(Num2Word_Base):
             elif n1 > 0 and not (i > 0 and x == 1):
                 words.append(ONES[n1][0])
 
-            if x > 0 and i > 0:
+            if i > 0:
                 words.append(self.pluralize(x, THOUSANDS[i]))
 
         return ' '.join(words)

--- a/num2words/lang_PL.py
+++ b/num2words/lang_PL.py
@@ -66,7 +66,7 @@ HUNDREDS = {
     6: ('sześćset',),
     7: ('siedemset',),
     8: ('osiemset',),
-    9: ('dziewęćset',),
+    9: ('dziewięćset',),
 }
 
 THOUSANDS = {

--- a/num2words/lang_PL.py
+++ b/num2words/lang_PL.py
@@ -70,27 +70,27 @@ HUNDREDS = {
 }
 
 THOUSANDS = {
-    1: ('tysiąc',       'tysiące',      'tysięcy'),       # 10^3
-    2: ('milion',       'miliony',      'milionów'),      # 10^6
-    3: ('miliard',      'miliardy',     'miliardów'),     # 10^9
-    4: ('bilion',       'biliony',      'bilionów'),      # 10^12
-    5: ('biliard',      'biliardy',     'biliardów'),     # 10^15
-    6: ('trylion',      'tryliony',     'trylionów'),     # 10^18
-    7: ('tryliard',     'tryliardy',    'tryliardów'),    # 10^21
-    8: ('kwadrylion',   'kwadryliony',  'kwadrylionów'),  # 10^24
-    9: ('kwadryliard',  'kwadryliardy', 'kwadryliardów'), # 10^27
-    10: ('kwintylion',  'kwintyliony',  'kwintylionów'),  # 10^30
-    11: ('kwintyliard', 'kwintyliardy', 'kwintyliardów'), # 10^33
-    12: ('sekstylion',  'sekstyliony',  'sekstylionów'),  # 10^36
-    13: ('sekstyliard', 'sekstyliardy', 'sekstyliardów'), # 10^39
-    14: ('septylion',   'septyliony',   'septylionów'),   # 10^42
-    15: ('septyliard',  'septyliardy',  'septyliardów'),  # 10^45
-    16: ('oktylion',    'oktyliony',    'oktylionów'),    # 10^48
-    17: ('oktyliard',   'oktyliardy',   'oktyliardów'),   # 10^51
-    18: ('nonylion',    'nonyliony',    'nonylionów'),    # 10^54
-    19: ('nonyliard',   'nonyliardy',   'nonyliardów'),   # 10^57
-    20: ('decylion',    'decyliony',    'decylionów'),    # 10^60
-    21: ('decyliard',   'decyliardy',   'decyliardów'),   # 10^63
+    1: ('tysiąc',       'tysiące',      'tysięcy'),        # 10^3
+    2: ('milion',       'miliony',      'milionów'),       # 10^6
+    3: ('miliard',      'miliardy',     'miliardów'),      # 10^9
+    4: ('bilion',       'biliony',      'bilionów'),       # 10^12
+    5: ('biliard',      'biliardy',     'biliardów'),      # 10^15
+    6: ('trylion',      'tryliony',     'trylionów'),      # 10^18
+    7: ('tryliard',     'tryliardy',    'tryliardów'),     # 10^21
+    8: ('kwadrylion',   'kwadryliony',  'kwadrylionów'),   # 10^24
+    9: ('kwadryliard',  'kwadryliardy', 'kwadryliardów'),  # 10^27
+    10: ('kwintylion',  'kwintyliony',  'kwintylionów'),   # 10^30
+    11: ('kwintyliard', 'kwintyliardy', 'kwintyliardów'),  # 10^33
+    12: ('sekstylion',  'sekstyliony',  'sekstylionów'),   # 10^36
+    13: ('sekstyliard', 'sekstyliardy', 'sekstyliardów'),  # 10^39
+    14: ('septylion',   'septyliony',   'septylionów'),    # 10^42
+    15: ('septyliard',  'septyliardy',  'septyliardów'),   # 10^45
+    16: ('oktylion',    'oktyliony',    'oktylionów'),     # 10^48
+    17: ('oktyliard',   'oktyliardy',   'oktyliardów'),    # 10^51
+    18: ('nonylion',    'nonyliony',    'nonylionów'),     # 10^54
+    19: ('nonyliard',   'nonyliardy',   'nonyliardów'),    # 10^57
+    20: ('decylion',    'decyliony',    'decylionów'),     # 10^60
+    21: ('decyliard',   'decyliardy',   'decyliardów'),    # 10^63
 }
 
 
@@ -103,11 +103,11 @@ class Num2Word_PL(Num2Word_Base):
             ('euro', 'euro', 'euro'), ('cent', 'centy', 'centów')
         ),
     }
-    
+
     def setup(self):
         self.negword = "minus"
         self.pointword = "przecinek"
-    
+
     def to_cardinal(self, number):
         n = str(number).replace(',', '.')
         if '.' in n:
@@ -119,7 +119,7 @@ class Num2Word_PL(Num2Word_Base):
             )
         else:
             return self._int2word(int(n))
-    
+
     def pluralize(self, n, forms):
         if n == 1:
             form = 0
@@ -128,33 +128,33 @@ class Num2Word_PL(Num2Word_Base):
         else:
             form = 2
         return forms[form]
-    
+
     def to_ordinal(self, number):
         raise NotImplementedError()
-    
+
     def _int2word(self, n):
         if n == 0:
             return ZERO[0]
-        
+
         words = []
         chunks = list(splitbyx(str(n), 3))
         i = len(chunks)
         for x in chunks:
             i -= 1
             n1, n2, n3 = get_digits(x)
-            
+
             if n3 > 0:
                 words.append(HUNDREDS[n3][0])
-            
+
             if n2 > 1:
                 words.append(TWENTIES[n2][0])
-            
+
             if n2 == 1:
                 words.append(TENS[n1][0])
             elif n1 > 0 and not (i > 0 and x == 1):
                 words.append(ONES[n1][0])
-            
+
             if i > 0:
                 words.append(self.pluralize(x, THOUSANDS[i]))
-        
+
         return ' '.join(words)

--- a/num2words/lang_RU.py
+++ b/num2words/lang_RU.py
@@ -223,7 +223,7 @@ class Num2Word_RU(Num2Word_Base):
                 ones = ONES_FEMININE if i == 1 or feminine and i == 0 else ONES
                 words.append(ones[n1][0])
 
-            if i > 0 and x != 0:
+            if x > 0 and i > 0:
                 words.append(self.pluralize(x, THOUSANDS[i]))
 
         return ' '.join(words)

--- a/num2words/lang_RU.py
+++ b/num2words/lang_RU.py
@@ -209,6 +209,10 @@ class Num2Word_RU(Num2Word_Base):
         i = len(chunks)
         for x in chunks:
             i -= 1
+
+            if x == 0:
+                continue
+
             n1, n2, n3 = get_digits(x)
 
             if n3 > 0:
@@ -223,7 +227,7 @@ class Num2Word_RU(Num2Word_Base):
                 ones = ONES_FEMININE if i == 1 or feminine and i == 0 else ONES
                 words.append(ones[n1][0])
 
-            if x > 0 and i > 0:
+            if i > 0:
                 words.append(self.pluralize(x, THOUSANDS[i]))
 
         return ' '.join(words)

--- a/num2words/lang_UK.py
+++ b/num2words/lang_UK.py
@@ -162,7 +162,7 @@ class Num2Word_UK(Num2Word_Base):
                 ones = ONES_FEMININE if i == 1 or feminine and i == 0 else ONES
                 words.append(ones[n1][0])
 
-            if i > 0 and ((n1 + n2 + n3) > 0):
+            if x > 0 and i > 0:
                 words.append(self.pluralize(x, THOUSANDS[i]))
 
         return ' '.join(words)

--- a/num2words/lang_UK.py
+++ b/num2words/lang_UK.py
@@ -147,6 +147,10 @@ class Num2Word_UK(Num2Word_Base):
         i = len(chunks)
         for x in chunks:
             i -= 1
+
+            if x == 0:
+                continue
+
             n1, n2, n3 = get_digits(x)
 
             if n3 > 0:
@@ -162,7 +166,7 @@ class Num2Word_UK(Num2Word_Base):
                 ones = ONES_FEMININE if i == 1 or feminine and i == 0 else ONES
                 words.append(ones[n1][0])
 
-            if x > 0 and i > 0:
+            if i > 0:
                 words.append(self.pluralize(x, THOUSANDS[i]))
 
         return ' '.join(words)

--- a/tests/test_lt.py
+++ b/tests/test_lt.py
@@ -53,9 +53,6 @@ class Num2WordsLTTest(TestCase):
             'minus penki tūkstančiai kablelis dvidešimt du',
         )
 
-        # print(fill(n2w(1000000000000000000000000000000)))
-        # naintilijonas
-
     def test_to_ordinal(self):
         # @TODO: implement to_ordinal
         with self.assertRaises(NotImplementedError):

--- a/tests/test_lv.py
+++ b/tests/test_lv.py
@@ -48,9 +48,6 @@ class Num2WordsLVTest(TestCase):
             'mīnus pieci tūkstoši komats divdesmit divi',
         )
 
-        # >>> print(fill(n2w(1000000000000000000000000000000)))
-        # nontiljons
-
         self.assertEqual(num2words(0, lang='lv'), 'nulle')
         self.assertEqual(num2words(5, lang='lv'), "pieci")
         self.assertEqual(num2words(15, lang='lv'), "piecpadsmit")

--- a/tests/test_pl.py
+++ b/tests/test_pl.py
@@ -46,6 +46,10 @@ class Num2WordsPLTest(TestCase):
             "sześćdziesiąt siedem tysięcy osiemset dziewięćdzisiąt"
         )
         self.assertEqual(
+            num2words(10000000001000000100000, lang='pl'),
+            "dziesięć tryliardów bilion sto tysięcy"
+        )
+        self.assertEqual(
             num2words(215461407892039002157189883901676, lang='pl'),
             "dwieście piętnaście kwintylionów czterysta sześćdziesiąt jeden "
             "kwadryliardów czterysta siedem kwadrylionów osiemset "

--- a/tests/test_pl.py
+++ b/tests/test_pl.py
@@ -70,19 +70,15 @@ class Num2WordsPLTest(TestCase):
         )
         self.assertEqual(
             num2words(
-                963301000001918264129471042047146102350812074235000101020000120324,
+                963301000001918264129471001047146102 * 10**30 + 1007,
                 lang='pl'
             ),
             "dziewięćset sześćdziesiąt trzy decyliardy trzysta jeden "
             "decylionów nonylion dziewięćset osiemnaście oktyliardów dwieście "
             "sześćdziesiąt cztery oktyliony sto dwadzieścia dziewięć "
             "septyliardów czterysta siedemdziesiąt jeden septylionów "
-            "czterdzieści dwa sekstyliardy czterdzieści siedem sekstylionów "
-            "sto czterdzieści sześć kwintyliardów sto dwa kwintyliony trzysta "
-            "pięćdziesiąt kwadryliardów osiemset dwanaście kwadrylionów "
-            "siedemdziesiąt cztery tryliardy dwieście trzydzieści pięć "
-            "trylionów sto jeden bilionów dwadzieścia miliardów sto "
-            "dwadzieścia tysięcy trzysta dwadzieścia cztery"
+            "sekstyliard czterdzieści siedem sekstylionów sto czterdzieści "
+            "sześć kwintyliardów sto dwa kwintyliony tysiąc siedem"
         )
 
     def test_to_ordinal(self):

--- a/tests/test_pl.py
+++ b/tests/test_pl.py
@@ -56,7 +56,7 @@ class Num2WordsPLTest(TestCase):
             "dziewięćdzisiąt dwa tryliardy trzydzieści dziewięć trylionów "
             "dwa biliardy sto pięćdziesiąt siedem bilionów sto osiemdziesiąt "
             "dziewięć miliardów osiemset osiemdziesiąt trzy miliony "
-            "dziewęćset jeden tysięcy sześćset siedemdziesiąt sześć"
+            "dziewięćset jeden tysięcy sześćset siedemdziesiąt sześć"
         )
         self.assertEqual(
             num2words(719094234693663034822824384220291, lang='pl'),

--- a/tests/test_pl.py
+++ b/tests/test_pl.py
@@ -64,6 +64,22 @@ class Num2WordsPLTest(TestCase):
             "osiemdziesiąt cztery miliony dwieście dwadzieścia "
             "tysięcy dwieście dziewięćdzisiąt jeden"
         )
+        self.assertEqual(
+            num2words(
+                963301000001918264129471042047146102350812074235000101020000120324,
+                lang='pl'
+            ),
+            "dziewięćset sześćdziesiąt trzy decyliardy trzysta jeden "
+            "decylionów nonylion dziewięćset osiemnaście oktyliardów dwieście "
+            "sześćdziesiąt cztery oktyliony sto dwadzieścia dziewięć "
+            "septyliardów czterysta siedemdziesiąt jeden septylionów "
+            "czterdzieści dwa sekstyliardy czterdzieści siedem sekstylionów "
+            "sto czterdzieści sześć kwintyliardów sto dwa kwintyliony trzysta "
+            "pięćdziesiąt kwadryliardów osiemset dwanaście kwadrylionów "
+            "siedemdziesiąt cztery tryliardy dwieście trzydzieści pięć "
+            "trylionów sto jeden bilionów dwadzieścia miliardów sto "
+            "dwadzieścia tysięcy trzysta dwadzieścia cztery"
+        )
 
     def test_to_ordinal(self):
         # @TODO: implement to_ordinal


### PR DESCRIPTION
## Fixes # by Marek Madejski

### Changes proposed in this pull request:

- typos in Polish names of 900 ("dziewięćset") and 10**27 (long scale - "kwadryliard")
- expanded PL names up to decilliard (10**63 - long scale,)
- words for power of thousand are no longer inserted if said power is 0 (e.g. in Polish: 1_000_000_000 => "miliard", not "miliard milionów tysięcy").

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Names:
https://pl.wikipedia.org/wiki/Liczebniki_główne_potęg_tysiąca#Nazwy_utrwalone_w_piśmiennictwie


### Additional notes



