### PR TITLE
Release 0.5.9

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Version 0.5.9 -- 2019/01/10
+---------------------------
+
+* Fix encoding issue on release 0.5.8 (#229)
+* Improve Polish localization (#228)
+
+
 Version 0.5.8 -- 2018/11/17
 ---------------------------
 

--- a/bin/num2words
+++ b/bin/num2words
@@ -55,7 +55,7 @@ import sys
 from docopt import docopt
 import num2words
 
-__version__ = "0.5.8"
+__version__ = "0.5.9"
 __license__ = "LGPL"
 
 


### PR DESCRIPTION
### New release 0.5.9
 I have made a pre-release, once this gets merged on master I will publish the new release on [github](https://github.com/savoirfairelinux/num2words/releases) and pypi you can test the pre-release uploaded on [test.pypi](https://test.pypi.org/project/num2words/). 