### PR TITLE
German improvements

### DIFF
--- a/num2words/lang_DE.py
+++ b/num2words/lang_DE.py
@@ -118,6 +118,8 @@ class Num2Word_DE(Num2Word_EU):
         # Exception: "hundertste" is usually preferred over "einhundertste"
         if res == "eintausendste" or res == "einhundertste":
             res = res.replace("ein", "", 1)
+        if res == "eine millionste":
+            res = res.replace("eine ", "", 1)
 
         return res
 

--- a/num2words/lang_DE.py
+++ b/num2words/lang_DE.py
@@ -17,6 +17,8 @@
 
 from __future__ import print_function, unicode_literals
 
+import re
+
 from .lang_EU import Num2Word_EU
 
 
@@ -107,7 +109,7 @@ class Num2Word_DE(Num2Word_EU):
 
     def to_ordinal(self, value):
         self.verify_ordinal(value)
-        outword = self.to_cardinal(value)
+        outword = self.to_cardinal(value).lower()
         for key in self.ords:
             if outword.endswith(key):
                 outword = outword[:len(outword) - len(key)] + self.ords[key]
@@ -118,8 +120,13 @@ class Num2Word_DE(Num2Word_EU):
         # Exception: "hundertste" is usually preferred over "einhundertste"
         if res == "eintausendste" or res == "einhundertste":
             res = res.replace("ein", "", 1)
-        if res == "eine Millionste":
-            res = res.replace("eine ", "", 1)
+        # ... similarly for "millionste" etc.
+        res = re.sub(r'eine ([a-z]+(illion|illiard)ste)$',
+                     lambda m: m.group(1), res)
+        # Ordinals involving "Million" etc. are written without a space.
+        # see https://de.wikipedia.org/wiki/Million#Sprachliches
+        res = re.sub(r' ([a-z]+(illion|illiard)ste)$',
+                     lambda m: m.group(1), res)
 
         return res
 

--- a/num2words/lang_DE.py
+++ b/num2words/lang_DE.py
@@ -45,7 +45,7 @@ class Num2Word_DE(Num2Word_EU):
         self.errmsg_toobig = "Die Zahl %s muss kleiner als %s sein."
         self.exclude_title = []
 
-        lows = ["non", "okt", "sept", "sext", "quint", "quadr", "tr", "b", "m"]
+        lows = ["Non", "Okt", "Sept", "Sext", "Quint", "Quadr", "Tr", "B", "M"]
         units = ["", "un", "duo", "tre", "quattuor", "quin", "sex", "sept",
                  "okto", "novem"]
         tens = ["dez", "vigint", "trigint", "quadragint", "quinquagint",
@@ -118,7 +118,7 @@ class Num2Word_DE(Num2Word_EU):
         # Exception: "hundertste" is usually preferred over "einhundertste"
         if res == "eintausendste" or res == "einhundertste":
             res = res.replace("ein", "", 1)
-        if res == "eine millionste":
+        if res == "eine Millionste":
             res = res.replace("eine ", "", 1)
 
         return res

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -23,7 +23,10 @@ from num2words import num2words
 
 
 class Num2WordsDETest(TestCase):
+
     def test_ordinal_less_than_twenty(self):
+        self.assertEqual(num2words(0, ordinal=True, lang='de'), "nullte")
+        self.assertEqual(num2words(1, ordinal=True, lang='de'), "erste")
         self.assertEqual(num2words(7, ordinal=True, lang='de'), "siebte")
         self.assertEqual(num2words(8, ordinal=True, lang='de'), "achte")
         self.assertEqual(num2words(12, ordinal=True, lang='de'), "zwölfte")

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -48,14 +48,17 @@ class Num2WordsDETest(TestCase):
             num2words(4000, ordinal=True, lang='de'), "viertausendste"
         )
         self.assertEqual(
-            num2words(1000000, ordinal=True, lang='de'), "Millionste"
+            num2words(1000000, ordinal=True, lang='de'), "millionste"
         )
         self.assertEqual(
-            num2words(2000000, ordinal=True, lang='de'), "zwei Millionste"
+            num2words(2000000, ordinal=True, lang='de'), "zweimillionste"
+        )
+        self.assertEqual(
+            num2words(1000000000, ordinal=True, lang='de'), "milliardste"
         )
         self.assertEqual(
             num2words(5000000000, ordinal=True, lang='de'),
-            "fünf Milliardste"
+            "fünfmilliardste"
         )
 
     def test_cardinal_at_some_numbers(self):

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -48,6 +48,9 @@ class Num2WordsDETest(TestCase):
             num2words(4000, ordinal=True, lang='de'), "viertausendste"
         )
         self.assertEqual(
+            num2words(1000000, ordinal=True, lang='de'), "millionste"
+        )
+        self.assertEqual(
             num2words(2000000, ordinal=True, lang='de'), "zwei millionste"
         )
         self.assertEqual(
@@ -57,6 +60,7 @@ class Num2WordsDETest(TestCase):
 
     def test_cardinal_at_some_numbers(self):
         self.assertEqual(num2words(100, lang='de'), "einhundert")
+        self.assertEqual(num2words(1000000, lang='de'), "eine million")
         self.assertEqual(num2words(2000000, lang='de'), "zwei millionen")
         self.assertEqual(num2words(4000000000, lang='de'), "vier milliarden")
         self.assertEqual(num2words(1000000000, lang='de'), "eine milliarde")

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -63,6 +63,9 @@ class Num2WordsDETest(TestCase):
 
     def test_cardinal_at_some_numbers(self):
         self.assertEqual(num2words(100, lang='de'), "einhundert")
+        self.assertEqual(num2words(1000, lang='de'), "eintausend")
+        self.assertEqual(num2words(5000, lang='de'), "fünftausend")
+        self.assertEqual(num2words(10000, lang='de'), "zehntausend")
         self.assertEqual(num2words(1000000, lang='de'), "eine Million")
         self.assertEqual(num2words(2000000, lang='de'), "zwei Millionen")
         self.assertEqual(num2words(4000000000, lang='de'), "vier Milliarden")

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -48,22 +48,22 @@ class Num2WordsDETest(TestCase):
             num2words(4000, ordinal=True, lang='de'), "viertausendste"
         )
         self.assertEqual(
-            num2words(1000000, ordinal=True, lang='de'), "millionste"
+            num2words(1000000, ordinal=True, lang='de'), "Millionste"
         )
         self.assertEqual(
-            num2words(2000000, ordinal=True, lang='de'), "zwei millionste"
+            num2words(2000000, ordinal=True, lang='de'), "zwei Millionste"
         )
         self.assertEqual(
             num2words(5000000000, ordinal=True, lang='de'),
-            "fünf milliardste"
+            "fünf Milliardste"
         )
 
     def test_cardinal_at_some_numbers(self):
         self.assertEqual(num2words(100, lang='de'), "einhundert")
-        self.assertEqual(num2words(1000000, lang='de'), "eine million")
-        self.assertEqual(num2words(2000000, lang='de'), "zwei millionen")
-        self.assertEqual(num2words(4000000000, lang='de'), "vier milliarden")
-        self.assertEqual(num2words(1000000000, lang='de'), "eine milliarde")
+        self.assertEqual(num2words(1000000, lang='de'), "eine Million")
+        self.assertEqual(num2words(2000000, lang='de'), "zwei Millionen")
+        self.assertEqual(num2words(4000000000, lang='de'), "vier Milliarden")
+        self.assertEqual(num2words(1000000000, lang='de'), "eine Milliarde")
 
     def test_cardinal_for_decimal_number(self):
         self.assertEqual(
@@ -73,8 +73,8 @@ class Num2WordsDETest(TestCase):
     def test_giant_cardinal_for_merge(self):
         self.assertEqual(
             num2words(4500072900000111, lang='de'),
-            "vier billiarden fünfhundert billionen " +
-            "zweiundsiebzig milliarden neunhundert millionen einhundertelf"
+            "vier Billiarden fünfhundert Billionen " +
+            "zweiundsiebzig Milliarden neunhundert Millionen einhundertelf"
         )
 
     def test_ordinal_num(self):


### PR DESCRIPTION
### Changes proposed in this pull request:

* ordinals: "Million" etc. is written in upper case
* cardinals: similar rule for 1 million etc. as for 100, 1000
* cardinals: several millions etc. are written without space
* add some more tests

### Status

- [X ] READY

### How to verify this change

https://de.wikipedia.org/wiki/Million#Sprachliches
