### PR TITLE
Fix typo 'seperator' on source code

### DIFF
--- a/num2words/base.py
+++ b/num2words/base.py
@@ -263,14 +263,14 @@ class Num2Word_Base(object):
     def _cents_terse(self, number, currency):
         return "%02d" % number
 
-    def to_currency(self, val, currency='EUR', cents=True, seperator=',',
+    def to_currency(self, val, currency='EUR', cents=True, separator=',',
                     adjective=False):
         """
         Args:
             val: Numeric value
             currency (str): Currency code
             cents (bool): Verbose cents
-            seperator (str): Cent seperator
+            separator (str): Cent separator
             adjective (bool): Prefix currency name with adjective
         Returns:
             str: Formatted string
@@ -297,7 +297,7 @@ class Num2Word_Base(object):
             minus_str,
             self.to_cardinal(left),
             self.pluralize(left, cr1),
-            seperator,
+            separator,
             cents_str,
             self.pluralize(right, cr2)
         )

--- a/num2words/lang_ES.py
+++ b/num2words/lang_ES.py
@@ -168,10 +168,10 @@ class Num2Word_ES(Num2Word_EU):
         self.verify_ordinal(value)
         return "%s%s" % (value, "º" if self.gender_stem == 'o' else "ª")
 
-    def to_currency(self, val, currency='EUR', cents=True, seperator=' con',
+    def to_currency(self, val, currency='EUR', cents=True, separator=' con',
                     adjective=False):
         result = super(Num2Word_ES, self).to_currency(
-            val, currency=currency, cents=cents, seperator=seperator,
+            val, currency=currency, cents=cents, separator=separator,
             adjective=adjective)
         # Handle exception, in spanish is "un euro" and not "uno euro"
         return result.replace("uno", "un")

--- a/num2words/lang_FI.py
+++ b/num2words/lang_FI.py
@@ -682,10 +682,10 @@ class Num2Word_FI(lang_EU.Num2Word_EU):
             suffix = suffix or " ennen ajanlaskun alkua"
         return self.to_cardinal(val).replace(" ", "") + suffix
 
-    def to_currency(self, val, currency="EUR", cents=True, seperator=" ja",
+    def to_currency(self, val, currency="EUR", cents=True, separator=" ja",
                     adjective=False):
         return super(Num2Word_FI, self).to_currency(
-            val, currency=currency, cents=cents, seperator=seperator,
+            val, currency=currency, cents=cents, separator=separator,
             adjective=adjective)
 
     def splitnum(self, value, options):

--- a/num2words/lang_HE.py
+++ b/num2words/lang_HE.py
@@ -131,7 +131,7 @@ def n2w(n):
     return int2word(int(n))
 
 
-def to_currency(n, currency='EUR', cents=True, seperator=','):
+def to_currency(n, currency='EUR', cents=True, separator=','):
     raise NotImplementedError()
 
 

--- a/num2words/lang_JA.py
+++ b/num2words/lang_JA.py
@@ -491,7 +491,7 @@ class Num2Word_JA(Num2Word_Base):
 
         return fmt % (era_name, era_year_words)
 
-    def to_currency(self, val, currency="JPY", cents=False, seperator="",
+    def to_currency(self, val, currency="JPY", cents=False, separator="",
                     adjective=False, reading=False, prefer=None):
         left, right, is_negative = parse_currency_parts(
             val, is_int_with_cents=cents)

--- a/num2words/lang_KO.py
+++ b/num2words/lang_KO.py
@@ -123,7 +123,7 @@ class Num2Word_KO(Num2Word_Base):
         return ("%s년" % valtext if not suffix
                 else "%s %s년" % (suffix, valtext))
 
-    def to_currency(self, val, currency="KRW", cents=False, seperator="",
+    def to_currency(self, val, currency="KRW", cents=False, separator="",
                     adjective=False):
         left, right, is_negative = parse_currency_parts(
             val, is_int_with_cents=cents)

--- a/num2words/lang_PT.py
+++ b/num2words/lang_PT.py
@@ -215,13 +215,13 @@ class Num2Word_PT(Num2Word_EU):
             return self.to_cardinal(abs(val)) + ' antes de Cristo'
         return self.to_cardinal(val)
 
-    def to_currency(self, val, currency='EUR', cents=True, seperator=' e',
+    def to_currency(self, val, currency='EUR', cents=True, separator=' e',
                     adjective=False):
         # change negword because base.to_currency() does not need space after
         backup_negword = self.negword
         self.negword = self.negword[:-1]
         result = super(Num2Word_PT, self).to_currency(
-            val, currency=currency, cents=cents, seperator=seperator,
+            val, currency=currency, cents=cents, separator=separator,
             adjective=adjective)
         # undo the change on negword
         self.negword = backup_negword

--- a/num2words/lang_SR.py
+++ b/num2words/lang_SR.py
@@ -173,14 +173,14 @@ class Num2Word_SR(Num2Word_Base):
 
         return ' '.join(words)
 
-    def to_currency(self, val, currency='EUR', cents=True, seperator=',',
+    def to_currency(self, val, currency='EUR', cents=True, separator=',',
                     adjective=False):
         """
         Args:
             val: Numeric value
             currency (str): Currency code
             cents (bool): Verbose cents
-            seperator (str): Cent seperator
+            separator (str): Cent separator
             adjective (bool): Prefix currency name with adjective
         Returns:
             str: Formatted string
@@ -210,7 +210,7 @@ class Num2Word_SR(Num2Word_Base):
             minus_str,
             self.to_cardinal(left, feminine=cr1[-1]),
             self.pluralize(left, cr1),
-            seperator,
+            separator,
             cents_str,
             self.pluralize(right, cr2)
         )

--- a/tests/test_cz.py
+++ b/tests/test_cz.py
@@ -84,11 +84,11 @@ class Num2WordsCZTest(TestCase):
             "tisíc dvěstě třicet čtyři koruny, padesát šest haléřů")
         self.assertEqual(
             num2words(101.11, lang='cz', to='currency', currency='EUR',
-                      seperator=' a'),
+                      separator=' a'),
             "sto jedna euro a jedenáct centů")
         self.assertEqual(
             num2words(101.21, lang='cz', to='currency', currency='CZK',
-                      seperator=' a'),
+                      separator=' a'),
             "sto jedna korun a dvacet jedna haléřů"
         )
         self.assertEqual(
@@ -97,7 +97,7 @@ class Num2WordsCZTest(TestCase):
         )
         self.assertEqual(
             num2words(123.50, lang='cz', to='currency', currency='CZK',
-                      seperator=' a'),
+                      separator=' a'),
             "sto dvacet tři koruny a padesát haléřů"
         )
         self.assertEqual(

--- a/tests/test_en.py
+++ b/tests/test_en.py
@@ -71,54 +71,54 @@ class Num2WordsENTest(TestCase):
 
     def test_to_currency(self):
         self.assertEqual(
-            num2words('38.4', lang='en', to='currency', seperator=' and',
+            num2words('38.4', lang='en', to='currency', separator=' and',
                       cents=False, currency='USD'),
             "thirty-eight dollars and 40 cents"
         )
         self.assertEqual(
-            num2words('0', lang='en', to='currency', seperator=' and',
+            num2words('0', lang='en', to='currency', separator=' and',
                       cents=False, currency='USD'),
             "zero dollars and 00 cents"
         )
 
         self.assertEqual(
-            num2words('1.01', lang='en', to='currency', seperator=' and',
+            num2words('1.01', lang='en', to='currency', separator=' and',
                       cents=True, currency='USD'),
             "one dollar and one cent"
         )
 
         self.assertEqual(
-            num2words('4778.00', lang='en', to='currency', seperator=' and',
+            num2words('4778.00', lang='en', to='currency', separator=' and',
                       cents=True, currency='USD', adjective=True),
             'four thousand, seven hundred and seventy-eight US dollars'
             ' and zero cents')
 
         self.assertEqual(
-            num2words('4778.00', lang='en', to='currency', seperator=' and',
+            num2words('4778.00', lang='en', to='currency', separator=' and',
                       cents=True, currency='USD'),
             'four thousand, seven hundred and seventy-eight dollars and'
             ' zero cents')
 
         self.assertEqual(
-            num2words('1.1', lang='en', to='currency', seperator=' and',
+            num2words('1.1', lang='en', to='currency', separator=' and',
                       cents=True, currency='MXN'),
             "one peso and ten cents"
         )
 
         self.assertEqual(
-            num2words('158.3', lang='en', to='currency', seperator=' and',
+            num2words('158.3', lang='en', to='currency', separator=' and',
                       cents=True, currency='MXN'),
             "one hundred and fifty-eight pesos and thirty cents"
         )
 
         self.assertEqual(
-            num2words('2000.00', lang='en', to='currency', seperator=' and',
+            num2words('2000.00', lang='en', to='currency', separator=' and',
                       cents=True, currency='MXN'),
             "two thousand pesos and zero cents"
         )
 
         self.assertEqual(
-            num2words('4.01', lang='en', to='currency', seperator=' and',
+            num2words('4.01', lang='en', to='currency', separator=' and',
                       cents=True, currency='MXN'),
             "four pesos and one cent"
         )

--- a/tests/test_lv.py
+++ b/tests/test_lv.py
@@ -106,12 +106,12 @@ class Num2WordsLVTest(TestCase):
         )
 
         self.assertEqual(
-            num2words(10111, lang='lv', to='currency', seperator=' un',
+            num2words(10111, lang='lv', to='currency', separator=' un',
                       currency='EUR'),
             "simtu viens eiro un vienpadsmit centi"
         )
         self.assertEqual(
-            num2words(10121, lang='lv', to='currency', seperator=' un',
+            num2words(10121, lang='lv', to='currency', separator=' un',
                       currency='LVL'),
             "simtu viens lats un divdesmit viens santīms"
         )
@@ -122,26 +122,26 @@ class Num2WordsLVTest(TestCase):
             " 85 centi"
         )
         self.assertEqual(
-            num2words('38.4', lang='lv', to='currency', seperator=' un',
+            num2words('38.4', lang='lv', to='currency', separator=' un',
                       cents=False, currency='EUR'),
             "trīsdesmit astoņi eiro un 40 centi"
         )
 
         # EUR legal form
         self.assertEqual(
-            num2words('38.4', lang='lv', to='currency', seperator=' un',
+            num2words('38.4', lang='lv', to='currency', separator=' un',
                       cents=False, currency='EUR_LEGAL'),
             "trīsdesmit astoņi euro un 40 centi"
         )
 
         self.assertEqual(
-            num2words('38.4', lang='lv', to='currency', seperator=' un',
+            num2words('38.4', lang='lv', to='currency', separator=' un',
                       cents=False, currency='USD', adjective=False),
             "trīsdesmit astoņi dolāri un 40 centi"
         )
 
         self.assertEqual(
-            num2words('38.4', lang='lv', to='currency', seperator=' un',
+            num2words('38.4', lang='lv', to='currency', separator=' un',
                       cents=False, currency='USD', adjective=True),
             "trīsdesmit astoņi ASV dolāri un 40 centi"
         )

--- a/tests/test_nl.py
+++ b/tests/test_nl.py
@@ -69,24 +69,24 @@ class Num2WordsNLTest(TestCase):
 
     def test_to_currency(self):
         self.assertEqual(
-            num2words('38.4', lang='nl', to='currency', seperator=' en',
+            num2words('38.4', lang='nl', to='currency', separator=' en',
                       cents=False, currency='EUR'),
             "achtendertig euro en 40 cent"
         )
         self.assertEqual(
-            num2words('0', lang='nl', to='currency', seperator=' en',
+            num2words('0', lang='nl', to='currency', separator=' en',
                       cents=False, currency='EUR'),
             "nul euro en 00 cent"
         )
 
         self.assertEqual(
-            num2words('1.01', lang='nl', to='currency', seperator=' en',
+            num2words('1.01', lang='nl', to='currency', separator=' en',
                       cents=True, currency='EUR'),
             "één euro en één cent"
         )
 
         self.assertEqual(
-            num2words('4778.00', lang='nl', to='currency', seperator=' en',
+            num2words('4778.00', lang='nl', to='currency', separator=' en',
                       cents=True, currency='EUR'),
             'vierduizendzevenhonderdachtenzeventig euro en nul cent')
 

--- a/tests/test_pl.py
+++ b/tests/test_pl.py
@@ -106,12 +106,12 @@ class Num2WordsPLTest(TestCase):
         )
         self.assertEqual(
             num2words(10111, lang='pl', to='currency', currency='EUR',
-                      seperator=' i'),
+                      separator=' i'),
             "sto jeden euro i jedenaście centów"
         )
         self.assertEqual(
             num2words(10121, lang='pl', to='currency', currency='PLN',
-                      seperator=' i'),
+                      separator=' i'),
             "sto jeden złotych i dwadzieścia jeden groszy"
         )
         self.assertEqual(
@@ -120,7 +120,7 @@ class Num2WordsPLTest(TestCase):
         )
         self.assertEqual(
             num2words(123.50, lang='pl', to='currency', currency='PLN',
-                      seperator=' i'),
+                      separator=' i'),
             "sto dwadzieścia trzy złote i pięćdziesiąt groszy"
         )
         self.assertEqual(

--- a/tests/test_ru.py
+++ b/tests/test_ru.py
@@ -170,22 +170,22 @@ class Num2WordsRUTest(TestCase):
         )
         self.assertEqual(
             num2words(10111, lang='ru', to='currency', currency='EUR',
-                      seperator=' и'),
+                      separator=' и'),
             'сто один евро и одиннадцать центов'
         )
         self.assertEqual(
             num2words(10121, lang='ru', to='currency', currency='RUB',
-                      seperator=' и'),
+                      separator=' и'),
             'сто один рубль и двадцать одна копейка'
         )
         self.assertEqual(
             num2words(10122, lang='ru', to='currency', currency='RUB',
-                      seperator=' и'),
+                      separator=' и'),
             'сто один рубль и двадцать две копейки'
         )
         self.assertEqual(
             num2words(10121, lang='ru', to='currency', currency='EUR',
-                      seperator=' и'),
+                      separator=' и'),
             'сто один евро и двадцать один цент'
         )
         self.assertEqual(
@@ -194,7 +194,7 @@ class Num2WordsRUTest(TestCase):
             'минус двенадцать тысяч пятьсот девятнадцать евро, 85 центов'
         )
         self.assertEqual(
-            num2words('38.4', lang='ru', to='currency', seperator=' и',
+            num2words('38.4', lang='ru', to='currency', separator=' и',
                       cents=False, currency='EUR'),
             "тридцать восемь евро и 40 центов"
         )

--- a/tests/test_sr.py
+++ b/tests/test_sr.py
@@ -203,7 +203,7 @@ class Num2WordsSRTest(TestCase):
                 lang='sr',
                 to='currency',
                 currency='EUR',
-                seperator=' i'
+                separator=' i'
             )
         )
         self.assertEqual(
@@ -213,18 +213,18 @@ class Num2WordsSRTest(TestCase):
                 lang='sr',
                 to='currency',
                 currency='RUB',
-                seperator=' i'
+                separator=' i'
             )
         )
         self.assertEqual(
             'sto jedna rublja i dvadeset dve kopejke',
             num2words(10122, lang='sr', to='currency', currency='RUB',
-                      seperator=' i')
+                      separator=' i')
         )
         self.assertEqual(
             'sto jedan evro i dvadeset jedan cent',
             num2words(10121, lang='sr', to='currency', currency='EUR',
-                      seperator=' i'),
+                      separator=' i'),
         )
         self.assertEqual(
             'minus dvanaest hiljada petsto devetnaest evra, 85 centi',
@@ -238,6 +238,6 @@ class Num2WordsSRTest(TestCase):
         )
         self.assertEqual(
             "trideset osam evra i 40 centi",
-            num2words('38.4', lang='sr', to='currency', seperator=' i',
+            num2words('38.4', lang='sr', to='currency', separator=' i',
                       cents=False, currency='EUR'),
         )

--- a/tests/test_uk.py
+++ b/tests/test_uk.py
@@ -100,27 +100,27 @@ class Num2WordsUKTest(TestCase):
         )
         # self.assertEqual(
         #     num2words(10111, lang='uk', to='currency', currency='EUR',
-        #               seperator=u' та'),
+        #               separator=u' та'),
         #     "сто один євро та одинадцять центiв"
         # )
         self.assertEqual(
             num2words(10121, lang='uk', to='currency', currency='UAH',
-                      seperator=u' та'),
+                      separator=u' та'),
             "сто одна гривня та двадцять одна копiйка"
         )
         self.assertEqual(
             num2words(10121, lang='uk', to='currency', currency='UAH',
-                      seperator=u' та'),
+                      separator=u' та'),
             "сто одна гривня та двадцять одна копiйка"
         )
         self.assertEqual(
             num2words(10122, lang='uk', to='currency', currency='UAH',
-                      seperator=u' та'),
+                      separator=u' та'),
             "сто одна гривня та двадцять двi копiйки"
         )
         # self.assertEqual(
         #     num2words(10121, lang='uk', to='currency', currency='EUR',
-        #               seperator=u' та'),
+        #               separator=u' та'),
         #     "сто один євро та двадцять один цент"
         # )
         self.assertEqual(
@@ -129,7 +129,7 @@ class Num2WordsUKTest(TestCase):
             "мiнус дванадцять тисяч п'ятсот дев'ятнадцять євро, 85 центiв"
         )
         self.assertEqual(
-            num2words('38.4', lang='uk', to='currency', seperator=' и',
+            num2words('38.4', lang='uk', to='currency', separator=' и',
                       cents=False, currency='EUR'),
             "тридцять вiсiм євро и 40 центiв"
         )


### PR DESCRIPTION
### Changes proposed in this pull request:

* Fix typo.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)
