### PR TITLE
Updates accents on céntimos in Spanish

### DIFF
--- a/num2words/lang_AR.py
+++ b/num2words/lang_AR.py
@@ -188,11 +188,11 @@ class Num2Word_AR(object):
                 ones = tens % 10
                 tens = (tens / 10) - 2
                 if ones > 0:
-                    if ret_val is not "" and tens < 4:
+                    if ret_val != "" and tens < 4:
                         ret_val += " و "
 
                     ret_val += self.digit_feminine_status(ones, group_level)
-                if ret_val is not "" and ones != 0:
+                if ret_val != "" and ones != 0:
                     ret_val += " و "
 
                 ret_val += self.arabicTens[int(tens)]
@@ -226,9 +226,9 @@ class Num2Word_AR(object):
                 self.process_arabic_group(number_to_process,
                                           group,
                                           Decimal(floor(temp_number)))
-            if group_description is not '':
+            if group_description != '':
                 if group > 0:
-                    if ret_val is not "":
+                    if ret_val != "":
                         ret_val = "{} و {}".format("", ret_val)
                     if number_to_process != 2:
                         if number_to_process % 100 != 1:
@@ -236,7 +236,7 @@ class Num2Word_AR(object):
                                 ret_val = "{} {}".format(
                                     self.arabicPluralGroups[group], ret_val)
                             else:
-                                if ret_val is not "":
+                                if ret_val != "":
                                     ret_val = "{} {}".format(
                                         self.arabicAppendedGroup[group],
                                         ret_val)
@@ -250,7 +250,7 @@ class Num2Word_AR(object):
                 ret_val = "{} {}".format(group_description, ret_val)
             group += 1
         formatted_number = ""
-        if self.arabicPrefixText is not "":
+        if self.arabicPrefixText != "":
             formatted_number += "{} ".format(self.arabicPrefixText)
         formatted_number += ret_val
         if self.integer_value != 0:
@@ -288,7 +288,7 @@ class Num2Word_AR(object):
             elif 11 <= remaining100 <= 99:
                 formatted_number += self.currency_subunit[3]
 
-        if self.arabicSuffixText is not "":
+        if self.arabicSuffixText != "":
             formatted_number += " {}".format(self.arabicSuffixText)
 
         return formatted_number
@@ -299,10 +299,10 @@ class Num2Word_AR(object):
         return number
 
     def set_currency_prefer(self, currency):
-        if currency is 'EGP':
+        if currency == 'EGP':
             self.currency_unit = CURRENCY_EGP[0]
             self.currency_subunit = CURRENCY_EGP[1]
-        elif currency is 'KWD':
+        elif currency == 'KWD':
             self.currency_unit = CURRENCY_KWD[0]
             self.currency_subunit = CURRENCY_KWD[1]
         else:

--- a/num2words/lang_ES.py
+++ b/num2words/lang_ES.py
@@ -22,10 +22,10 @@ from .lang_EU import Num2Word_EU
 
 class Num2Word_ES(Num2Word_EU):
     CURRENCY_FORMS = {
-        'EUR': (('euro', 'euros'), ('centimo', 'centimos')),
-        'ESP': (('peseta', 'pesetas'), ('centimo', 'centimos')),
-        'USD': (('dolar', 'dolares'), ('centavo', 'centavos')),
-        'PEN': (('sol', 'soles'), ('centimo', 'centimos')),
+        'EUR': (('euro', 'euros'), ('céntimo', 'céntimos')),
+        'ESP': (('peseta', 'pesetas'), ('céntimo', 'céntimos')),
+        'USD': (('dolar', 'dólares'), ('centavo', 'centavos')),
+        'PEN': (('sol', 'soles'), ('céntimo', 'céntimos')),
     }
 
     # //CHECK: Is this sufficient??

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -106,7 +106,7 @@ class CliTestCase(unittest.TestCase):
         output = self.cli.run_cmd(150.55, '--lang', 'es', '--to', 'currency')
         self.assertEqual(output.return_code, 0)
         self.assertEqual(
-            (output.out.decode('utf-8') if hasattr(output.out, 'decode') else \
+            (output.out.decode('utf-8') if hasattr(output.out, 'decode') else
              output.out).strip(),
             "ciento cincuenta euros con cincuenta y cinco céntimos"
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -107,5 +107,5 @@ class CliTestCase(unittest.TestCase):
         self.assertEqual(output.return_code, 0)
         self.assertEqual(
             output.out.strip(),
-            "ciento cincuenta euros con cincuenta y cinco centimos"
+            "ciento cincuenta euros con cincuenta y cinco céntimos"
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -106,6 +106,6 @@ class CliTestCase(unittest.TestCase):
         output = self.cli.run_cmd(150.55, '--lang', 'es', '--to', 'currency')
         self.assertEqual(output.return_code, 0)
         self.assertEqual(
-            output.out.strip().decode('utf-8'),
+            (output.out.decode('utf-8') if hasattr(output.out, 'decode') else output.out).strip(),
             "ciento cincuenta euros con cincuenta y cinco céntimos"
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -106,6 +106,6 @@ class CliTestCase(unittest.TestCase):
         output = self.cli.run_cmd(150.55, '--lang', 'es', '--to', 'currency')
         self.assertEqual(output.return_code, 0)
         self.assertEqual(
-            output.out.strip(),
+            output.out.strip().decode('utf-8'),
             "ciento cincuenta euros con cincuenta y cinco céntimos"
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -106,6 +106,6 @@ class CliTestCase(unittest.TestCase):
         output = self.cli.run_cmd(150.55, '--lang', 'es', '--to', 'currency')
         self.assertEqual(output.return_code, 0)
         self.assertEqual(
-            output.out.strip().decode('utf-8'),
+            output.out.strip(),
             "ciento cincuenta euros con cincuenta y cinco céntimos"
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -104,12 +104,9 @@ class CliTestCase(unittest.TestCase):
         """You should be able to specify a language
         """
         output = self.cli.run_cmd(150.55, '--lang', 'es', '--to', 'currency')
-        if hasattr(output.out, 'decode'):
-            out = output.out.decode('utf-8').strip()
-        else:
-            out = output.out.strip()
         self.assertEqual(output.return_code, 0)
         self.assertEqual(
-            out,
+            (output.out.decode('utf-8') if hasattr(output.out, 'decode') else \
+             output.out).strip(),
             "ciento cincuenta euros con cincuenta y cinco céntimos"
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -104,8 +104,12 @@ class CliTestCase(unittest.TestCase):
         """You should be able to specify a language
         """
         output = self.cli.run_cmd(150.55, '--lang', 'es', '--to', 'currency')
+        if hasattr(output.out, 'decode'):
+            out = output.out.decode('utf-8').strip()
+        else:
+            out = output.out.strip()
         self.assertEqual(output.return_code, 0)
         self.assertEqual(
-            (output.out.decode('utf-8') if hasattr(output.out, 'decode') else output.out).strip(),
+            out,
             "ciento cincuenta euros con cincuenta y cinco céntimos"
         )

--- a/tests/test_es.py
+++ b/tests/test_es.py
@@ -112,25 +112,25 @@ TEST_CASES_ORDINAL_NUM = (
 )
 
 TEST_CASES_TO_CURRENCY = (
-    (1.00, 'un euro con cero centimos'),
-    (2.00, 'dos euros con cero centimos'),
-    (8.00, 'ocho euros con cero centimos'),
-    (12.00, 'doce euros con cero centimos'),
-    (21.00, 'veintiun euros con cero centimos'),
-    (81.25, 'ochenta y un euros con veinticinco centimos'),
-    (350.90, 'trescientos cincuenta euros con noventa centimos'),
-    (100.00, 'cien euros con cero centimos'),
+    (1.00, 'un euro con cero céntimos'),
+    (2.00, 'dos euros con cero céntimos'),
+    (8.00, 'ocho euros con cero céntimos'),
+    (12.00, 'doce euros con cero céntimos'),
+    (21.00, 'veintiun euros con cero céntimos'),
+    (81.25, 'ochenta y un euros con veinticinco céntimos'),
+    (350.90, 'trescientos cincuenta euros con noventa céntimos'),
+    (100.00, 'cien euros con cero céntimos'),
 )
 
 TEST_CASES_TO_CURRENCY_ESP = (
-    (1.00, 'un peseta con cero centimos'),
-    (2.00, 'dos pesetas con cero centimos'),
-    (8.00, 'ocho pesetas con cero centimos'),
-    (12.00, 'doce pesetas con cero centimos'),
-    (21.00, 'veintiun pesetas con cero centimos'),
-    (81.25, 'ochenta y un pesetas con veinticinco centimos'),
-    (350.90, 'trescientos cincuenta pesetas con noventa centimos'),
-    (100.00, 'cien pesetas con cero centimos'),
+    (1.00, 'un peseta con cero céntimos'),
+    (2.00, 'dos pesetas con cero céntimos'),
+    (8.00, 'ocho pesetas con cero céntimos'),
+    (12.00, 'doce pesetas con cero céntimos'),
+    (21.00, 'veintiun pesetas con cero céntimos'),
+    (81.25, 'ochenta y un pesetas con veinticinco céntimos'),
+    (350.90, 'trescientos cincuenta pesetas con noventa céntimos'),
+    (100.00, 'cien pesetas con cero céntimos'),
 )
 
 TEST_CASES_TO_CURRENCY_USD = (
@@ -145,14 +145,14 @@ TEST_CASES_TO_CURRENCY_USD = (
 )
 
 TEST_CASES_TO_CURRENCY_PEN = (
-    (1.00, 'un sol con cero centimos'),
-    (2.00, 'dos soles con cero centimos'),
-    (8.00, 'ocho soles con cero centimos'),
-    (12.00, 'doce soles con cero centimos'),
-    (21.00, 'veintiun soles con cero centimos'),
-    (81.25, 'ochenta y un soles con veinticinco centimos'),
-    (350.90, 'trescientos cincuenta soles con noventa centimos'),
-    (100.00, 'cien soles con cero centimos'),
+    (1.00, 'un sol con cero céntimos'),
+    (2.00, 'dos soles con cero céntimos'),
+    (8.00, 'ocho soles con cero céntimos'),
+    (12.00, 'doce soles con cero céntimos'),
+    (21.00, 'veintiun soles con cero céntimos'),
+    (81.25, 'ochenta y un soles con veinticinco céntimos'),
+    (350.90, 'trescientos cincuenta soles con noventa céntimos'),
+    (100.00, 'cien soles con cero céntimos'),
 )
 
 

--- a/tests/test_es.py
+++ b/tests/test_es.py
@@ -135,13 +135,13 @@ TEST_CASES_TO_CURRENCY_ESP = (
 
 TEST_CASES_TO_CURRENCY_USD = (
     (1.00, 'un dolar con cero centavos'),
-    (2.00, 'dos dolares con cero centavos'),
-    (8.00, 'ocho dolares con cero centavos'),
-    (12.00, 'doce dolares con cero centavos'),
-    (21.00, 'veintiun dolares con cero centavos'),
-    (81.25, 'ochenta y un dolares con veinticinco centavos'),
-    (350.90, 'trescientos cincuenta dolares con noventa centavos'),
-    (100.00, 'cien dolares con cero centavos'),
+    (2.00, 'dos dólares con cero centavos'),
+    (8.00, 'ocho dólares con cero centavos'),
+    (12.00, 'doce dólares con cero centavos'),
+    (21.00, 'veintiun dólares con cero centavos'),
+    (81.25, 'ochenta y un dólares con veinticinco centavos'),
+    (350.90, 'trescientos cincuenta dólares con noventa centavos'),
+    (100.00, 'cien dólares con cero centavos'),
 )
 
 TEST_CASES_TO_CURRENCY_PEN = (

--- a/tox.ini
+++ b/tox.ini
@@ -26,3 +26,7 @@ deps =
     delegator.py
 commands =
     isort --check-only --recursive --diff num2words tests
+
+[testenv:py27]
+setenv =
+    PYTHONIOENCODING = UTF-8


### PR DESCRIPTION
## Fixes # by Álvaro Durán

### Changes proposed in this pull request:

* Fixes Spanish language


### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

This is a cosmetic change: make sure that the accent in 'céntimos' is there when running num2words with `to='currency'`.

### Additional notes

