### PR TITLE
Let python take care of newlines

### DIFF
--- a/bin/num2words
+++ b/bin/num2words
@@ -72,21 +72,18 @@ def main():
     args = docopt(__doc__, argv=None, help=True, version=version, options_first=False)
     if args["--list-languages"]:
         for lang in get_languages():
-            sys.stdout.write(lang)
-            sys.stdout.write(os.linesep)
+            print(lang)
         sys.exit(0)
     if args["--list-converters"]:
         for lang in get_converters():
-            sys.stdout.write(lang)
-            sys.stdout.write(os.linesep)
+            print(lang)
         sys.exit(0)
     try:
-        words = num2words.num2words(args['<number>'], lang=args['--lang'], to=args['--to'])
-        sys.stdout.write(words+os.linesep)
+        print(num2words.num2words(args['<number>'], lang=args['--lang'], to=args['--to']))
         sys.exit(0)
     except Exception as err:
         sys.stderr.write(str(args['<number>']))
-        sys.stderr.write(str(err) + os.linesep)
+        print(str(err))
         sys.stderr.write(__doc__)
         sys.exit(1)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,12 +58,12 @@ class CliTestCase(unittest.TestCase):
         output = self.cli.run_cmd('--list-languages')
         self.assertEqual(
             sorted(list(num2words.CONVERTER_CLASSES.keys())),
-            output.out.strip().split(os.linesep)
+            output.out.strip().splitlines()
         )
         output = self.cli.run_cmd('-L')
         self.assertEqual(
             sorted(list(num2words.CONVERTER_CLASSES.keys())),
-            output.out.strip().split(os.linesep)
+            output.out.strip().splitlines()
         )
 
     def test_cli_list_converters(self):
@@ -72,12 +72,12 @@ class CliTestCase(unittest.TestCase):
         output = self.cli.run_cmd('--list-converters')
         self.assertEqual(
             sorted(list(num2words.CONVERTES_TYPES)),
-            output.out.strip().split(os.linesep)
+            output.out.strip().splitlines()
         )
         output = self.cli.run_cmd('-C')
         self.assertEqual(
             sorted(list(num2words.CONVERTES_TYPES)),
-            output.out.strip().split(os.linesep)
+            output.out.strip().splitlines()
         )
 
     def test_cli_default_lang(self):


### PR DESCRIPTION
### Changes proposed in this pull request:

This PR modifies the `num2words` CLI and its tests to let python handle the newlines, mainly by using `print` and `str.splitlines` instead of calls including `os.linesep`. This should improve functionality on windows.
 
### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Run the unit tests.

### Additional notes

[The docs](https://docs.python.org/3/library/os.html#os.linesep) say not to use os.linesep when writing to streams opened in text mode (which includes `sys.stdout`)

