### PR TITLE
Provide num2words script as entry-point

### DIFF
--- a/num2words/__init__.py
+++ b/num2words/__init__.py
@@ -52,6 +52,9 @@ from . import lang_SR
 from . import lang_TH
 from . import lang_KO
 
+__version__ = "0.5.9"
+__license__ = "LGPL"
+
 CONVERTER_CLASSES = {
     'ar': lang_AR.Num2Word_AR(),
     'cz': lang_CZ.Num2Word_CZ(),

--- a/num2words/__main__.py
+++ b/num2words/__main__.py
@@ -53,10 +53,8 @@ from __future__ import print_function, unicode_literals
 import os
 import sys
 from docopt import docopt
-import num2words
 
-__version__ = "0.5.9"
-__license__ = "LGPL"
+import num2words
 
 
 def get_languages():
@@ -68,7 +66,7 @@ def get_converters():
 
 
 def main():
-    version = "{}=={}".format(os.path.basename(__file__), __version__)
+    version = "{}=={}".format("num2words", num2words.__version__)
     args = docopt(__doc__, argv=None, help=True, version=version, options_first=False)
     if args["--list-languages"]:
         for lang in get_languages():

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 # MA 02110-1301 USA
 
+import os.path
 import re
 from io import open
 
@@ -58,7 +59,7 @@ def find_version(fname):
 
 setup(
     name=PACKAGE_NAME,
-    version=find_version("bin/num2words"),
+    version=find_version(os.path.join("num2words", "__init__.py")),
     description='Modules to convert numbers to words. Easily extensible.',
     long_description=LONG_DESC,
     license='LGPL',
@@ -73,7 +74,11 @@ setup(
     packages=find_packages(exclude=['tests']),
     test_suite='tests',
     classifiers=CLASSIFIERS,
-    scripts=['bin/num2words'],
+    entry_points={
+        "console_scripts": [
+            "num2words=num2words.__main__:main",
+        ],
+    },
     install_requires=["docopt>=0.6.2"],
     tests_require=['delegator.py'],
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,9 +28,7 @@ import num2words
 class CliCaller(object):
 
     def __init__(self):
-        self.cmd = os.path.realpath(os.path.join(os.path.dirname(__file__),
-                                    "..", "bin", "num2words"))
-        self.cmd_list = ["python", self.cmd]
+        self.cmd_list = ["python", "-m", "num2words"]
 
     def run_cmd(self, *args):
         cmd_list = self.cmd_list + [str(arg) for arg in args]


### PR DESCRIPTION
### Changes proposed in this pull request:

* provide `num2words` CLI as an `entry-point`, rather than a script, this should improve support for cross-platform deployment, specifically with `conda` on windows, where `PATH` manipulation is tricksy
* move the `__version__` definition from the script to the `__init__.py` and update references accordinly

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Run the unit tests.

### Additional notes

I have attempted to build a [conda recipe](https://github.com/conda-forge/staged-recipes/pull/7753) for this (excellent) package, which is failing because installing scripts is a bit fiddly, its much easier with entry points.

