### PR TITLE
Fixing currency functions for german and french. Adding Currency_Forms for DE, FR and NL.

### DIFF
--- a/num2words/lang_DE.py
+++ b/num2words/lang_DE.py
@@ -23,6 +23,14 @@ from .lang_EU import Num2Word_EU
 
 
 class Num2Word_DE(Num2Word_EU):
+    CURRENCY_FORMS = {
+        'EUR': (('Euro', 'Euro'), ('Cent', 'Cent')),
+        'GBP': (('Pfund', 'Pfund'), ('Penny', 'Pence')),
+        'USD': (('Dollar', 'Dollar'), ('Cent', 'Cent')),
+        'CNY': (('Yuan', 'Yuan'), ('Jiao', 'Fen')),
+        'DEM': (('Mark', 'Mark'), ('Pfennig', 'Pfennig')),
+    }
+
     GIGA_SUFFIX = "illiarde"
     MEGA_SUFFIX = "illion"
 
@@ -134,22 +142,13 @@ class Num2Word_DE(Num2Word_EU):
         self.verify_ordinal(value)
         return str(value) + "."
 
-    def to_currency(self, val, longval=True, old=False):
-        hightxt = "Euro"
-        lowtxt = "Cent"
-        if old:
-            hightxt = "Mark"
-            lowtxt = "Pfennig/e"
-
-        cents = int(round(val*100))
-        res = self.to_splitnum(cents, hightxt=hightxt, lowtxt=lowtxt,
-                               jointxt="und", longval=longval)
-
+    def to_currency(self, val, currency='EUR', cents=True, separator=' und',
+                    adjective=False):
+        result = super(Num2Word_DE, self).to_currency(
+            val, currency=currency, cents=cents, separator=separator,
+            adjective=adjective)
         # Handle exception, in german is "ein Euro" and not "eins Euro"
-        if res.startswith("eins "):
-            res = res.replace("eins ", "ein ", 1)
-
-        return res
+        return result.replace("eins ", "ein ")
 
     def to_year(self, val, longval=True):
         if not (val // 100) % 10:

--- a/num2words/lang_FR.py
+++ b/num2words/lang_FR.py
@@ -21,6 +21,14 @@ from .lang_EU import Num2Word_EU
 
 
 class Num2Word_FR(Num2Word_EU):
+    CURRENCY_FORMS = {
+        'EUR': (('euro', 'euros'), ('centime', 'centimes')),
+        'USD': (('dollar', 'dollars'), ('cent', 'cents')),
+        'FRF': (('franc', 'francs'), ('centime', 'centimes')),
+        'GBP': (('livre', 'livres'), ('penny', 'pence')),
+        'CNY': (('yuan', 'yuans'), ('fen', 'jiaos')),
+    }
+
     def setup(self):
         Num2Word_EU.setup(self)
 
@@ -92,10 +100,9 @@ class Num2Word_FR(Num2Word_EU):
         out += "er" if value == 1 else "me"
         return out
 
-    def to_currency(self, val, longval=True, old=False):
-        hightxt = "euro/s"
-        if old:
-            hightxt = "franc/s"
-        cents = int(round(val*100))
-        return self.to_splitnum(cents, hightxt=hightxt, lowtxt="centime/s",
-                                divisor=100, jointxt="et", longval=longval)
+    def to_currency(self, val, currency='EUR', cents=True, separator=' et',
+                    adjective=False):
+        result = super(Num2Word_FR, self).to_currency(
+            val, currency=currency, cents=cents, separator=separator,
+            adjective=adjective)
+        return result

--- a/num2words/lang_FR_DZ.py
+++ b/num2words/lang_FR_DZ.py
@@ -21,8 +21,13 @@ from .lang_FR import Num2Word_FR
 
 
 class Num2Word_FR_DZ(Num2Word_FR):
-    def to_currency(self, val, longval=True, cents=True, jointxt="virgule"):
-        return self.to_splitnum(
-            val, hightxt="dinard/s", lowtxt="centime/s", divisor=1,
-            jointxt=jointxt, longval=longval, cents=cents
-        )
+    CURRENCY_FORMS = {
+        'DIN': (('dinard', 'dinards'), ('centime', 'centimes')),
+    }
+
+    def to_currency(self, val, currency='DIN', cents=True, separator=' et',
+                    adjective=False):
+        result = super(Num2Word_FR, self).to_currency(
+            val, currency=currency, cents=cents, separator=separator,
+            adjective=adjective)
+        return result

--- a/num2words/lang_NL.py
+++ b/num2words/lang_NL.py
@@ -22,7 +22,10 @@ from .lang_EU import Num2Word_EU
 
 class Num2Word_NL(Num2Word_EU):
     CURRENCY_FORMS = {
-        'EUR': (('euro', 'euros'), ('cent', 'cents')),
+        'EUR': (('euro', 'euro'), ('cent', 'cent')),
+        'GBP': (('pond', 'pond'), ('penny', 'pence')),
+        'USD': (('dollar', 'dollar'), ('cent', 'cent')),
+        'CNY': (('yuan', 'yuan'), ('jiao', 'fen')),
     }
 
     GIGA_SUFFIX = "iljard"

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -21,6 +21,46 @@ from unittest import TestCase
 
 from num2words import num2words
 
+TEST_CASES_TO_CURRENCY_EUR = (
+    (1.00, 'ein Euro und null Cent'),
+    (2.01, 'zwei Euro und ein Cent'),
+    (8.10, 'acht Euro und zehn Cent'),
+    (12.26, 'zwölf Euro und sechsundzwanzig Cent'),
+    (21.29, 'einundzwanzig Euro und neunundzwanzig Cent'),
+    (81.25, 'einundachtzig Euro und fünfundzwanzig Cent'),
+    (100.00, 'einhundert Euro und null Cent'),
+)
+
+TEST_CASES_TO_CURRENCY_USD = (
+    (1.00, 'ein Dollar und null Cent'),
+    (2.01, 'zwei Dollar und ein Cent'),
+    (8.10, 'acht Dollar und zehn Cent'),
+    (12.26, 'zwölf Dollar und sechsundzwanzig Cent'),
+    (21.29, 'einundzwanzig Dollar und neunundzwanzig Cent'),
+    (81.25, 'einundachtzig Dollar und fünfundzwanzig Cent'),
+    (100.00, 'einhundert Dollar und null Cent'),
+)
+
+TEST_CASES_TO_CURRENCY_GBP = (
+    (1.00, 'ein Pfund und null Pence'),
+    (2.01, 'zwei Pfund und ein Penny'),
+    (8.10, 'acht Pfund und zehn Pence'),
+    (12.26, 'zwölf Pfund und sechsundzwanzig Pence'),
+    (21.29, 'einundzwanzig Pfund und neunundzwanzig Pence'),
+    (81.25, 'einundachtzig Pfund und fünfundzwanzig Pence'),
+    (100.00, 'einhundert Pfund und null Pence'),
+)
+
+TEST_CASES_TO_CURRENCY_DEM = (
+    (1.00, 'ein Mark und null Pfennig'),
+    (2.01, 'zwei Mark und ein Pfennig'),
+    (8.10, 'acht Mark und zehn Pfennig'),
+    (12.26, 'zwölf Mark und sechsundzwanzig Pfennig'),
+    (21.29, 'einundzwanzig Mark und neunundzwanzig Pfennig'),
+    (81.25, 'einundachtzig Mark und fünfundzwanzig Pfennig'),
+    (100.00, 'einhundert Mark und null Pfennig'),
+)
+
 
 class Num2WordsDETest(TestCase):
 
@@ -93,30 +133,33 @@ class Num2WordsDETest(TestCase):
     def test_ordinal_for_floating_numbers(self):
         self.assertRaises(TypeError, num2words, 2.453, ordinal=True, lang='de')
 
-    def test_currency(self):
-        self.assertEqual(num2words(1.01, lang='de', to='currency'),
-                         'ein Euro und ein Cent')
-        self.assertEqual(num2words(12.00, lang='de', to='currency'),
-                         'zwölf Euro und null Cent')
-        self.assertEqual(num2words(12.00, lang='de', to='currency'),
-                         'zwölf Euro und null Cent')
-        self.assertEqual(num2words(100.0, lang='de', to='currency'),
-                         "einhundert Euro und null Cent")
-        self.assertEqual(num2words(190.01, lang='de', to='currency'),
-                         "einhundertneunzig Euro und ein Cent")
-        self.assertEqual(num2words(1.90, lang='de', to='currency'),
-                         "ein Euro und neunzig Cent")
-        self.assertEqual(num2words(3.4, lang='de', to='currency'),
-                         "drei Euro und vierzig Cent")
-        self.assertEqual(num2words(20.18, lang='de', to='currency'),
-                         "zwanzig Euro und achtzehn Cent")
-        self.assertEqual(num2words(3.04, lang='de', to='currency'),
-                         "drei Euro und vier Cent")
+    def test_currency_eur(self):
+        for test in TEST_CASES_TO_CURRENCY_EUR:
+            self.assertEqual(
+                num2words(test[0], lang='de', to='currency', currency='EUR'),
+                test[1]
+            )
 
-    def test_old_currency(self):
-        self.assertEqual(num2words(12.00, to='currency', lang='de',
-                                   currency='DEM'),
-                         'zwölf Mark und null Pfennig')
+    def test_currency_usd(self):
+        for test in TEST_CASES_TO_CURRENCY_USD:
+            self.assertEqual(
+                num2words(test[0], lang='de', to='currency', currency='USD'),
+                test[1]
+            )
+
+    def test_currency_dem(self):
+        for test in TEST_CASES_TO_CURRENCY_DEM:
+            self.assertEqual(
+                num2words(test[0], lang='de', to='currency', currency='DEM'),
+                test[1]
+            )
+
+    def test_currency_gbp(self):
+        for test in TEST_CASES_TO_CURRENCY_GBP:
+            self.assertEqual(
+                num2words(test[0], lang='de', to='currency', currency='GBP'),
+                test[1]
+            )
 
     def test_year(self):
         self.assertEqual(num2words(2002, to='year', lang='de'),

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -94,16 +94,16 @@ class Num2WordsDETest(TestCase):
         self.assertRaises(TypeError, num2words, 2.453, ordinal=True, lang='de')
 
     def test_currency(self):
-        self.assertEqual(num2words(1, lang='de', to='currency'),
-                         'ein Euro')
-        self.assertEqual(num2words(12, lang='de', to='currency'),
-                         'zwölf Euro')
+        self.assertEqual(num2words(1.01, lang='de', to='currency'),
+                         'ein Euro und ein Cent')
         self.assertEqual(num2words(12.00, lang='de', to='currency'),
-                         'zwölf Euro')
+                         'zwölf Euro und null Cent')
+        self.assertEqual(num2words(12.00, lang='de', to='currency'),
+                         'zwölf Euro und null Cent')
         self.assertEqual(num2words(100.0, lang='de', to='currency'),
-                         "einhundert Euro")
-        self.assertEqual(num2words(190, lang='de', to='currency'),
-                         "einhundertneunzig Euro")
+                         "einhundert Euro und null Cent")
+        self.assertEqual(num2words(190.01, lang='de', to='currency'),
+                         "einhundertneunzig Euro und ein Cent")
         self.assertEqual(num2words(1.90, lang='de', to='currency'),
                          "ein Euro und neunzig Cent")
         self.assertEqual(num2words(3.4, lang='de', to='currency'),
@@ -114,8 +114,9 @@ class Num2WordsDETest(TestCase):
                          "drei Euro und vier Cent")
 
     def test_old_currency(self):
-        self.assertEqual(num2words(12.00, to='currency', lang='de', old=True),
-                         'zwölf Mark')
+        self.assertEqual(num2words(12.00, to='currency', lang='de',
+                                   currency='DEM'),
+                         'zwölf Mark und null Pfennig')
 
     def test_year(self):
         self.assertEqual(num2words(2002, to='year', lang='de'),

--- a/tests/test_fr.py
+++ b/tests/test_fr.py
@@ -138,6 +138,16 @@ TEST_CASES_TO_CURRENCY_FRF = (
     (100.00, 'cent francs et zéro centimes'),
 )
 
+TEST_CASES_TO_CURRENCY_USD = (
+    (1.00, 'un dollar et zéro cents'),
+    (2.01, 'deux dollars et un cent'),
+    (8.10, 'huit dollars et dix cents'),
+    (12.26, 'douze dollars et vingt-six cents'),
+    (21.29, 'vingt et un dollars et vingt-neuf cents'),
+    (81.25, 'quatre-vingt-un dollars et vingt-cinq cents'),
+    (100.00, 'cent dollars et zéro cents'),
+)
+
 
 class Num2WordsENTest(TestCase):
     def test_ordinal_special_joins(self):
@@ -184,5 +194,12 @@ class Num2WordsENTest(TestCase):
         for test in TEST_CASES_TO_CURRENCY_FRF:
             self.assertEqual(
                 num2words(test[0], lang='fr', to='currency', currency='FRF'),
+                test[1]
+            )
+
+    def test_currency_usd(self):
+        for test in TEST_CASES_TO_CURRENCY_USD:
+            self.assertEqual(
+                num2words(test[0], lang='fr', to='currency', currency='USD'),
                 test[1]
             )

--- a/tests/test_fr.py
+++ b/tests/test_fr.py
@@ -118,26 +118,24 @@ TEST_CASES_ORDINAL_NUM = (
     (1000000, '1000000me')
 )
 
-TEST_CASES_TO_CURRENCY = (
-    (1, 'un euro'),
-    (2, 'deux euros'),
-    (8, 'huit euros'),
-    (12, 'douze euros'),
-    (21, 'vingt et un euros'),
+TEST_CASES_TO_CURRENCY_EUR = (
+    (1.00, 'un euro et zéro centimes'),
+    (2.01, 'deux euros et un centime'),
+    (8.10, 'huit euros et dix centimes'),
+    (12.26, 'douze euros et vingt-six centimes'),
+    (21.29, 'vingt et un euros et vingt-neuf centimes'),
     (81.25, 'quatre-vingt-un euros et vingt-cinq centimes'),
-    (81.2, 'quatre-vingt-un euros et vingt centimes'),
-    (100, 'cent euros'),
+    (100.00, 'cent euros et zéro centimes'),
 )
 
-TEST_CASES_TO_CURRENCY_OLD = (
-    (1, 'un franc'),
-    (2, 'deux francs'),
-    (8, 'huit francs'),
-    (12, 'douze francs'),
-    (21, 'vingt et un francs'),
+TEST_CASES_TO_CURRENCY_FRF = (
+    (1.00, 'un franc et zéro centimes'),
+    (2.01, 'deux francs et un centime'),
+    (8.10, 'huit francs et dix centimes'),
+    (12.27, 'douze francs et vingt-sept centimes'),
+    (21.29, 'vingt et un francs et vingt-neuf centimes'),
     (81.25, 'quatre-vingt-un francs et vingt-cinq centimes'),
-    (81.2, 'quatre-vingt-un francs et vingt centimes'),
-    (100, 'cent francs'),
+    (100.00, 'cent francs et zéro centimes'),
 )
 
 
@@ -175,16 +173,16 @@ class Num2WordsENTest(TestCase):
                 test[1]
             )
 
-    def test_currency(self):
-        for test in TEST_CASES_TO_CURRENCY:
+    def test_currency_eur(self):
+        for test in TEST_CASES_TO_CURRENCY_EUR:
             self.assertEqual(
-                num2words(test[0], lang='fr', to='currency'),
+                num2words(test[0], lang='fr', to='currency', currency='EUR'),
                 test[1]
             )
 
-    def test_currency_old(self):
-        for test in TEST_CASES_TO_CURRENCY_OLD:
+    def test_currency_frf(self):
+        for test in TEST_CASES_TO_CURRENCY_FRF:
             self.assertEqual(
-                num2words(test[0], lang='fr', to='currency', old=True),
+                num2words(test[0], lang='fr', to='currency', currency='FRF'),
                 test[1]
             )

--- a/tests/test_fr_be.py
+++ b/tests/test_fr_be.py
@@ -54,24 +54,24 @@ TEST_CASES_ORDINAL = (
     (1000000000000000000, 'un trillionsième')  # over 1e18 is not supported
 )
 
-TEST_CASES_TO_CURRENCY = (
-    (1, 'un euro'),
-    (2, 'deux euros'),
-    (8, 'huit euros'),
-    (12, 'douze euros'),
-    (21, 'vingt et un euros'),
+TEST_CASES_TO_CURRENCY_EUR = (
+    (1.00, 'un euro et zéro centimes'),
+    (2.01, 'deux euros et un centime'),
+    (8.10, 'huit euros et dix centimes'),
+    (12.26, 'douze euros et vingt-six centimes'),
+    (21.29, 'vingt et un euros et vingt-neuf centimes'),
     (81.25, 'quatre-vingt et un euros et vingt-cinq centimes'),
-    (100, 'cent euros'),
+    (100.00, 'cent euros et zéro centimes'),
 )
 
-TEST_CASES_TO_CURRENCY_OLD = (
-    (1, 'un franc'),
-    (2, 'deux francs'),
-    (8, 'huit francs'),
-    (12, 'douze francs'),
-    (21, 'vingt et un francs'),
+TEST_CASES_TO_CURRENCY_FRF = (
+    (1.00, 'un franc et zéro centimes'),
+    (2.01, 'deux francs et un centime'),
+    (8.10, 'huit francs et dix centimes'),
+    (12.27, 'douze francs et vingt-sept centimes'),
+    (21.29, 'vingt et un francs et vingt-neuf centimes'),
     (81.25, 'quatre-vingt et un francs et vingt-cinq centimes'),
-    (100, 'cent francs'),
+    (100.00, 'cent francs et zéro centimes'),
 )
 
 # Lang to execute current test
@@ -114,16 +114,16 @@ class Num2WordsENTest(TestCase):
                 test[1]
             )
 
-    def test_currency(self):
-        for test in TEST_CASES_TO_CURRENCY:
+    def test_currency_eur(self):
+        for test in TEST_CASES_TO_CURRENCY_EUR:
             self.assertEqual(
                 num2words(test[0], lang=LANG, to='currency'),
                 test[1]
             )
 
-    def test_currency_old(self):
-        for test in TEST_CASES_TO_CURRENCY_OLD:
+    def test_currency_frf(self):
+        for test in TEST_CASES_TO_CURRENCY_FRF:
             self.assertEqual(
-                num2words(test[0], lang=LANG, to='currency', old=True),
+                num2words(test[0], lang=LANG, to='currency', currency='FRF'),
                 test[1]
             )

--- a/tests/test_fr_ch.py
+++ b/tests/test_fr_ch.py
@@ -55,24 +55,24 @@ TEST_CASES_ORDINAL = (
     (1000000000000000000, 'un trillionsième')  # over 1e18 is not supported
 )
 
-TEST_CASES_TO_CURRENCY = (
-    (1, 'un euro'),
-    (2, 'deux euros'),
-    (8, 'huit euros'),
-    (12, 'douze euros'),
-    (21, 'vingt et un euros'),
+TEST_CASES_TO_CURRENCY_EUR = (
+    (1.00, 'un euro et zéro centimes'),
+    (2.01, 'deux euros et un centime'),
+    (8.10, 'huit euros et dix centimes'),
+    (12.26, 'douze euros et vingt-six centimes'),
+    (21.29, 'vingt et un euros et vingt-neuf centimes'),
     (81.25, 'huitante et un euros et vingt-cinq centimes'),
-    (100, 'cent euros'),
+    (100.00, 'cent euros et zéro centimes'),
 )
 
-TEST_CASES_TO_CURRENCY_OLD = (
-    (1, 'un franc'),
-    (2, 'deux francs'),
-    (8, 'huit francs'),
-    (12, 'douze francs'),
-    (21, 'vingt et un francs'),
+TEST_CASES_TO_CURRENCY_FRF = (
+    (1.00, 'un franc et zéro centimes'),
+    (2.01, 'deux francs et un centime'),
+    (8.10, 'huit francs et dix centimes'),
+    (12.27, 'douze francs et vingt-sept centimes'),
+    (21.29, 'vingt et un francs et vingt-neuf centimes'),
     (81.25, 'huitante et un francs et vingt-cinq centimes'),
-    (100, 'cent francs'),
+    (100.00, 'cent francs et zéro centimes'),
 )
 
 
@@ -111,16 +111,17 @@ class Num2WordsENTest(TestCase):
                 test[1]
             )
 
-    def test_currency(self):
-        for test in TEST_CASES_TO_CURRENCY:
+    def test_currency_eur(self):
+        for test in TEST_CASES_TO_CURRENCY_EUR:
             self.assertEqual(
                 num2words(test[0], lang='fr_CH', to='currency'),
                 test[1]
             )
 
-    def test_currency_old(self):
-        for test in TEST_CASES_TO_CURRENCY_OLD:
+    def test_currency_frf(self):
+        for test in TEST_CASES_TO_CURRENCY_FRF:
             self.assertEqual(
-                num2words(test[0], lang='fr_CH', to='currency', old=True),
+                num2words(test[0], lang='fr_CH', to='currency',
+                          currency='FRF'),
                 test[1]
             )

--- a/tests/test_fr_dz.py
+++ b/tests/test_fr_dz.py
@@ -29,7 +29,7 @@ TEST_CASES_TO_CURRENCY = (
     (8, 'huit dinards'),
     (12, 'douze dinards'),
     (21, 'vingt et un dinards'),
-    (81.25, 'quatre-vingt-un dinards virgule vingt-cinq centimes'),
+    (81.25, 'quatre-vingt-un dinards et vingt-cinq centimes'),
     (100, 'cent dinards'),
 )
 
@@ -38,11 +38,11 @@ class Num2WordsPLTest(TestCase):
     def test_currency(self):
         self.assertEqual(
             num2words(1234.12, lang='fr_DZ', to='currency'),
-            "mille deux cent trente-quatre dinards virgule douze centimes"
+            "mille deux cent trente-quatre dinards et douze centimes"
         )
         self.assertEqual(
             num2words(45689.89, lang='fr_DZ', to='currency'),
-            "quarante-cinq mille six cent quatre-vingt-neuf dinards virgule "
+            "quarante-cinq mille six cent quatre-vingt-neuf dinards et "
             "quatre-vingt-neuf centimes"
         )
 

--- a/tests/test_nl.py
+++ b/tests/test_nl.py
@@ -67,7 +67,7 @@ class Num2WordsNLTest(TestCase):
     def test_ordinal_for_floating_numbers(self):
         self.assertRaises(TypeError, num2words, 2.453, ordinal=True, lang='nl')
 
-    def test_to_currency(self):
+    def test_to_currency_eur(self):
         self.assertEqual(
             num2words('38.4', lang='nl', to='currency', separator=' en',
                       cents=False, currency='EUR'),
@@ -89,6 +89,29 @@ class Num2WordsNLTest(TestCase):
             num2words('4778.00', lang='nl', to='currency', separator=' en',
                       cents=True, currency='EUR'),
             'vierduizendzevenhonderdachtenzeventig euro en nul cent')
+
+    def test_to_currency_usd(self):
+        self.assertEqual(
+            num2words('38.4', lang='nl', to='currency', separator=' en',
+                      cents=False, currency='USD'),
+            "achtendertig dollar en 40 cent"
+        )
+        self.assertEqual(
+            num2words('0', lang='nl', to='currency', separator=' en',
+                      cents=False, currency='USD'),
+            "nul dollar en 00 cent"
+        )
+
+        self.assertEqual(
+            num2words('1.01', lang='nl', to='currency', separator=' en',
+                      cents=True, currency='USD'),
+            "één dollar en één cent"
+        )
+
+        self.assertEqual(
+            num2words('4778.00', lang='nl', to='currency', separator=' en',
+                      cents=True, currency='USD'),
+            'vierduizendzevenhonderdachtenzeventig dollar en nul cent')
 
     def test_pluralize(self):
         n = Num2Word_NL()


### PR DESCRIPTION
## Fixes # 
by Sarah Beranek

### Changes proposed in this pull request:

* Adding CURRENCY_FORMS for German and French
* Replacing old currency functions with updated ones for German and French.
* Adding more CURRENCY_FORMS options for dutch

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change                                                                                                                                                                             

```
lang='de'                                                                                     
var1 = '49.95'                                                                                                                                 
var2 = '1.01'                                                                              
b = num2words(var1, lang=lang, to='currency', currency='USD')
print(b)                                                               
d = num2words(var2, lang=lang, to='currency', currency='EUR')
print(d) 
```

the same test for French with setting `lang='fr'` or Dutch with `lang='nl'` 

### Additional notes

I think for most of the languages if there is only an integer value given the currency should be euro/dollar and not cent per default.
I see that there is a possible option `is_int_with_cents` in the `parse_currency_parts` function to address this, which is not used yet. 

Maybe it is a good idea to propagate this to the specific language ` to_currency ` functions? 
If you agree - I can do the changes, if I find the time.

