### PR TITLE
Add support for the Indian rupee.

### DIFF
--- a/num2words/lang_EU.py
+++ b/num2words/lang_EU.py
@@ -42,6 +42,7 @@ class Num2Word_EU(Num2Word_Base):
         'PLN': (('zloty', 'zlotys', 'zlotu'), ('grosz', 'groszy')),
         'MXN': (('peso', 'pesos'), GENERIC_CENTS),
         'RON': (('leu', 'lei'), ('ban', 'bani')),
+        'INR': (('rupee', 'rupees'), ('paisa', 'paise'))
     }
 
     CURRENCY_ADJECTIVES = {
@@ -53,6 +54,7 @@ class Num2Word_EU(Num2Word_Base):
         'NOK': 'Norwegian',
         'MXN': 'Mexican',
         'RON': 'Romanian',
+        'INR': 'Indian',
     }
 
     GIGA_SUFFIX = "illiard"


### PR DESCRIPTION
### Changes proposed in this pull request:

* Add support for the Indian rupee. 

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

`num2words('102541.34', to='currency', currency='INR', adjective=True)`

### Additional notes

The standard currency code used internationally for the Indian Rupee is the INR. The added currency forms for the Indian Rupee are linked to the 'INR' code. The change is made in the Num2Word_EU class, where most of the currency forms seem to be. In principle, the provided forms are valid for English and similar languages.

