### PR TITLE
to_date() and to_time() methods implemented on PT_BR

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,9 @@
-## Fixes # by...
+## Fixes # by Cassio Batista and Eric Pereira
 
 ### Changes proposed in this pull request:
 
-* ...
-* ...
+* method `to_date()` implemented for PT\_BR 
+* method `to_time()` implemented for PT\_BR 
 
 ### Status
 
@@ -13,7 +13,39 @@
 
 ### How to verify this change
 
-*Fill out this section so that a reviewer can know how to verify your change.*
+Usage:
+```
+./num2words <TIME_FMT> -l pt_BR -t time
+./num2words <DATE_FMT> -l pt_BR -t date
+
+	<TIME_FMT>: hh:mm    | h:mm 
+	<DATE_FMT>: dd/mm/yy | dd/mm/yy
+```
+
+```bash
+user@host $ ./num2words "2:54" -l pt_BR -t time
+  dois horas e cinquenta e quatro minutos
+user@host $ ./num2words "2:00" -l pt_BR -t time
+  dois horas # FIXME: gender issues
+user@host $ ./num2words "22:59" -l pt_BR -t time
+  vinte e dois horas e cinquenta e nove minutos
+user@host $ ./num2words "23:59" -l pt_BR -t time
+  vinte e três horas e cinquenta e nove minutos
+user@host $ ./num2words "11:30" -l pt_BR -t time
+  onze horas e trinta minutos
+user@host $ ./num2words "1:30" -l pt_BR -t time
+  um hora e trinta minutos
+user@host $ ./num2words "12/12/12" -l pt_BR -t date
+  doze de dezembro de dois mil e doze
+user@host $ ./num2words "3:10" -l pt_BR -t time
+  três horas e dez minutos
+user@host $ ./num2words "31/3/2009" -l pt_BR -t date
+  trinta e um de março de dois mil e nove
+user@host $ ./num2words "31/3/1998" -l pt_BR -t date
+  trinta e um de março de mil, novecentos e noventa e oito
+
+```
+
 
 ### Additional notes
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -22,22 +22,23 @@ Usage:
 	<DATE_FMT>: dd/mm/yy | dd/mm/yy
 ```
 
+Examples:
 ```bash
-user@host $ ./num2words "2:54" -l pt_BR -t time
+user@host $ ./num2words "2:54"      -l pt_BR -t time
   dois horas e cinquenta e quatro minutos
-user@host $ ./num2words "2:00" -l pt_BR -t time
+user@host $ ./num2words "2:00"      -l pt_BR -t time
   dois horas # FIXME: gender issues
-user@host $ ./num2words "22:59" -l pt_BR -t time
+user@host $ ./num2words "22:59"     -l pt_BR -t time
   vinte e dois horas e cinquenta e nove minutos
-user@host $ ./num2words "23:59" -l pt_BR -t time
+user@host $ ./num2words "23:59"     -l pt_BR -t time
   vinte e três horas e cinquenta e nove minutos
-user@host $ ./num2words "11:30" -l pt_BR -t time
+user@host $ ./num2words "11:30 "    -l pt_BR -t time
   onze horas e trinta minutos
-user@host $ ./num2words "1:30" -l pt_BR -t time
+user@host $ ./num2words "1:30"      -l pt_BR -t time
   um hora e trinta minutos
-user@host $ ./num2words "12/12/12" -l pt_BR -t date
+user@host $ ./num2words "12/12/12"  -l pt_BR -t date
   doze de dezembro de dois mil e doze
-user@host $ ./num2words "3:10" -l pt_BR -t time
+user@host $ ./num2words "3:10"      -l pt_BR -t time
   três horas e dez minutos
 user@host $ ./num2words "31/3/2009" -l pt_BR -t date
   trinta e um de março de dois mil e nove
@@ -45,7 +46,6 @@ user@host $ ./num2words "31/3/1998" -l pt_BR -t date
   trinta e um de março de mil, novecentos e noventa e oito
 
 ```
-
 
 ### Additional notes
 

--- a/num2words/__init__.py
+++ b/num2words/__init__.py
@@ -62,7 +62,10 @@ CONVERTER_CLASSES = {
 }
 
 
-CONVERTES_TYPES = ['cardinal', 'ordinal', 'ordinal_num', 'year', 'currency']
+CONVERTES_TYPES = [
+    'cardinal', 'ordinal', 'ordinal_num', 
+    'year', 'currency', 'time', 'date',
+    ]
 
 
 def num2words(number, ordinal=False, lang='en', to='cardinal', **kwargs):
@@ -74,7 +77,8 @@ def num2words(number, ordinal=False, lang='en', to='cardinal', **kwargs):
         raise NotImplementedError()
     converter = CONVERTER_CLASSES[lang]
     if isinstance(number, str):
-        number = converter.str_to_number(number)
+        if to != 'date' and to != 'time':
+            number = converter.str_to_number(number)
     # backwards compatible
     if ordinal:
         return converter.to_ordinal(number)

--- a/num2words/lang_PT_BR.py
+++ b/num2words/lang_PT_BR.py
@@ -116,7 +116,7 @@ class Num2Word_PT_BR(lang_PT.Num2Word_PT):
 
     def to_date(self, val):
         map_month = {
-            u'01':'janeiro',     u'1':'janeiro'
+            u'01':'janeiro',     u'1':'janeiro',
             u'02':'fevereiro',   u'2':'fevereiro',
             u'03':'março',       u'3':'março',
             u'04':'abril',       u'4':'abril',

--- a/num2words/lang_PT_BR.py
+++ b/num2words/lang_PT_BR.py
@@ -113,3 +113,50 @@ class Num2Word_PT_BR(lang_PT.Num2Word_PT):
                 result += ' centavos'
 
         return result
+
+    def to_date(self, val):
+        map_month = {
+            u'01':'janeiro',     u'1':'janeiro'
+            u'02':'fevereiro',   u'2':'fevereiro',
+            u'03':'março',       u'3':'março',
+            u'04':'abril',       u'4':'abril',
+            u'05':'maio',        u'5':'maio',
+            u'06':'junho',       u'6':'junho',
+            u'07':'julho',       u'7':'julho',
+            u'08':'agosto',      u'8':'agosto',
+            u'09':'setembro',    u'9':'setembro',
+            u'10':'outubro',
+            u'11':'novembro',
+            u'12':'dezembro',
+        }
+
+        # NOTE supports only dd/mm/[yy|yyyy]
+        day          = '(3[0-1]|[12][0-9]|0?[1-9])'
+        month        = '(1[0-2]|[0]?[1-9])'
+        year         = '(1[4-9]|2[0-1])([0-9][0-9])'
+        short_year   = '([09][0-9]|1[0-9])'
+        pattern_date = re.compile(r'^%s/%s/(%s|%s)$' % \
+                    (day, month, year, short_year))
+
+        if re.search(pattern_date, val) is None:
+            print('deu ruim')
+            return None
+
+        vals  = val.split('/')
+
+        year = vals[-1]
+        if int(year) < 20:
+            year = '20' + year
+        year = self.str_to_number(year)
+        year = self.to_cardinal(year)
+
+        month = vals[-2]
+        month = map_month[month]
+
+        day = vals[-3]
+        day = self.str_to_number(day)
+        if day == 1:
+            day = self.to_ordinal(day)
+        else:
+            day = self.to_cardinal(day)
+        return '%s de %s de %s' % (day, month, year)

--- a/num2words/lang_PT_BR.py
+++ b/num2words/lang_PT_BR.py
@@ -160,3 +160,45 @@ class Num2Word_PT_BR(lang_PT.Num2Word_PT):
         else:
             day = self.to_cardinal(day)
         return '%s de %s de %s' % (day, month, year)
+
+    def to_time(self, val):
+        hour         = '(2[0-3]|[01]?[0-9])'
+        minute       = '([0-5]?[0-9])(h?)'
+        short_hour   = '(2[0-3]|[01]?[0-9])h'
+        pattern_time = re.compile(r'^(%s:%s|%s|%sh%s|%sh%s)$' % \
+                    (hour, minute, short_hour, hour, minute, short_hour, minute))
+
+        if re.search(pattern_time, val) is None:
+            print('deu ruim')
+            return None
+
+        vals = val.split(':')
+        h_unit = 'hora'
+        m_unit = 'minuto'
+        if len(vals) == 1:   # single hour
+            hour = vals[0].replace('h','')
+            if int(hour) > 1:
+                h_unit += 's' 
+            hour = self.str_to_number(hour)
+            hour = self.to_cardinal(hour) + ' '
+            return hour + ' ' + h_unit
+        elif len(vals) == 2: # hours and minutes
+            hour = vals[0].replace('h','') 
+            if int(hour) > 1:
+                h_unit += 's'
+            hour = self.str_to_number(hour)
+            hour = self.to_cardinal(hour)
+
+            mins = vals[1].replace('m','')
+            if int(mins) == 0:
+                mins    = ''
+                m_unit  = ''
+            elif int(mins) == 1:
+                mins = self.str_to_number(mins)
+                mins = ' e ' + self.to_cardinal(mins)
+            elif int(mins) > 1:
+                mins = self.str_to_number(mins)
+                mins = ' e ' + self.to_cardinal(mins)
+                m_unit += 's'
+
+            return hour + ' ' + h_unit + mins + ' ' + m_unit

--- a/tests/test_pt_BR.py
+++ b/tests/test_pt_BR.py
@@ -393,3 +393,11 @@ class Num2WordsPTBRTest(TestCase):
             'setecentos e quarenta e quatro antes de Cristo'
         )
         self.assertEqual(self.n2w.to_year(-10000), 'dez mil antes de Cristo')
+
+    def test_date(self):
+        self.assertEqual(self.n2w.to_date('12/12/12'), 
+            'doze de dezembro de dois mil e doze')
+
+    def test_time(self):
+        self.assertEqual(self.n2w.to_time('3:10'), 
+            'três horas e dez minutos')


### PR DESCRIPTION
## Fixes # by @cassiobatista and @eriicf

### Changes proposed in this pull request:

* method `to_date()` implemented for PT\_BR: converts numbers from calendar date format to string
* method `to_time()` implemented for PT\_BR: converts numbers in digital clock time format to string

### Status

- [ ] READY
- [ ] HOLD
- [X] WIP (Work-In-Progress)

### How to verify this change

Usage:
```
./num2words <TIME_FMT> -l pt_BR -t time
./num2words <DATE_FMT> -l pt_BR -t date

	<TIME_FMT>: hh:mm    | h:mm 
	<DATE_FMT>: dd/mm/yy | dd/mm/yy
```

Examples:
```bash
user@host $ ./num2words "2:54"      -l pt_BR -t time
  dois horas e cinquenta e quatro minutos    # FIXME: gender issues
user@host $ ./num2words "2:00"      -l pt_BR -t time
  dois horas   # FIXME: gender issues
user@host $ ./num2words "22:59"     -l pt_BR -t time
  vinte e dois horas e cinquenta e nove minutos
user@host $ ./num2words "23:59"     -l pt_BR -t time
  vinte e três horas e cinquenta e nove minutos
user@host $ ./num2words "11:30 "    -l pt_BR -t time
  onze horas e trinta minutos
user@host $ ./num2words "1:30"      -l pt_BR -t time
  um hora e trinta minutos  # FIXME: gender issues
user@host $ ./num2words "12/12/12"  -l pt_BR -t date
  doze de dezembro de dois mil e doze
user@host $ ./num2words "31/3/2009" -l pt_BR -t date
  trinta e um de março de dois mil e nove
user@host $ ./num2words "31/3/1998" -l pt_BR -t date
  trinta e um de março de mil, novecentos e noventa e oito
```

### Additional notes

Unfortunately I couldn't figure out how to exec the methods inside the test class, but as soon as I have time I will. Nevertheless all the examples provided above seem to be up and running.