### PR TITLE
Bugfix for PLN currency in lang_PL.py

### DIFF
--- a/num2words/lang_PL.py
+++ b/num2words/lang_PL.py
@@ -163,3 +163,19 @@ class Num2Word_PL(Num2Word_Base):
                 words.append(self.pluralize(x, THOUSANDS[i]))
 
         return ' '.join(words)
+
+    def to_currency(
+            self,
+            val,
+            currency='PLN',
+            cents=True,
+            seperator=',',
+            adjective=False
+    ):
+        return super(Num2Word_PL, self).to_currency(
+            val,
+            currency=currency,
+            cents=cents,
+            seperator=seperator,
+            adjective=adjective
+        )


### PR DESCRIPTION
## Fixes by @ptynecki

### Changes proposed in this pull request:

* Fixed PLN currency support in lang_PL.py

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Before changes:
```python
num2words(1220.04, lang='pl', to='currency')
```

Returns:
```
tysiąc dwieście dwadzieścia euro, cztery centy
```
What was wrong because EURO/cents are not in Poland yet.

After the fix, section below:
```python
num2words(1220.04, lang='pl', to='currency')
```

Returns:
```
tysiąc dwieście dwadzieścia złotych, cztery grosze
```
