### PR TITLE
Revert some copyright changes made in commit 53b4518

### DIFF
--- a/num2words/lang_IT.py
+++ b/num2words/lang_IT.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2003, Taro Ogawa.  All Rights Reserved.
-# Copyright (c) 2013, Savoir-faire Linux inc.  All Rights Reserved.
+# Copyright (c) 2018-2019, Filippo Costa.  All Rights Reserved.
 
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/test_tr.py
+++ b/tests/test_tr.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright (c) 2017, Tufan Kaynak, Framras.  All Rights Reserved.
 # Copyright (c) 2003, Taro Ogawa.  All Rights Reserved.
 # Copyright (c) 2013, Savoir-faire Linux inc.  All Rights Reserved.
 


### PR DESCRIPTION
Commit 53b4518 made added explicit utf-8 encoding for all sources, among other things. A copyright notice in `tests/test_tr.py` was mistakenly removed and two were added in `num2words/lang_it.py`. I know this was a simple overlook, I just thought it would be best to explicitly give credit where credit is due.