### PR TITLE
Bugfix: Danish ordinals for 3X, 4X, 6X, 100, 1000, ...

### DIFF
--- a/num2words/lang_DK.py
+++ b/num2words/lang_DK.py
@@ -101,7 +101,9 @@ class Num2Word_DK(lang_EU.Num2Word_EU):
             if outword.endswith(key):
                 outword = outword[:len(outword) - len(key)] + self.ords[key]
                 break
-        if 30 <= value % 100 <= 39:
+        if 0 == value:
+            outword += "te"
+        elif 30 <= value % 100 <= 39:
             outword = outword.rstrip("e") + "te"
         elif 40 <= value % 100 <= 49:
             outword += "nde"

--- a/num2words/lang_DK.py
+++ b/num2words/lang_DK.py
@@ -101,9 +101,13 @@ class Num2Word_DK(lang_EU.Num2Word_EU):
             if outword.endswith(key):
                 outword = outword[:len(outword) - len(key)] + self.ords[key]
                 break
-        if value % 100 >= 30 and value % 100 <= 39 or value % 100 == 0:
-            outword += "te"
-        elif value % 100 > 12 or value % 100 == 0:
+        if 30 <= value % 100 <= 39:
+            outword = outword.rstrip("e") + "te"
+        elif 40 <= value % 100 <= 49:
+            outword += "nde"
+        elif 60 <= value % 100 <= 69:
+            outword += "sende"
+        elif value % 100 > 12:
             outword += "ende"
         return outword
 


### PR DESCRIPTION
## Fixes # by Jens Larsen

Fixed the following issues for Danish ordinals: 3X, 4X, 6X, 100, 1000, ...

WRONG: 3X. --> tredivete
CORRECT: 3X. --> tredivte

WRONG: 4X. --> fyrreende
CORRECT: 4X. --> fyrrende

WRONG: 6X. --> tresende
CORRECT: 6X. --> tressende

WRONG: 100. --> et hundredete
CORRECT: 100. --> et hundrede

WRONG: 1000. --> et tusindete
CORRECT: 1000. --> et tusinde

### Status

- [X ] READY
- [ ] HOLD
- [] WIP (Work-In-Progress)

