### PR TITLE
Add the attribute for Num2Word_VI class

### DIFF
--- a/num2words/lang_VI.py
+++ b/num2words/lang_VI.py
@@ -16,6 +16,7 @@
 # MA 02110-1301 USA
 
 from __future__ import unicode_literals
+from decimal import Decimal
 
 to_19 = (u'không', u'một', u'hai', u'ba', u'bốn', u'năm', u'sáu',
          u'bảy', u'tám', u'chín', u'mười', u'mười một', u'mười hai',
@@ -93,6 +94,9 @@ class Num2Word_VI(object):
             end_word = self.vietnam_number(int(the_list[1]))
             final_result = final_result + ' phẩy ' + end_word
         return final_result
+
+    def str_to_number(self, value):
+        return Decimal(value)
 
     def to_cardinal(self, number):
         return self.number_to_text(number)


### PR DESCRIPTION
### Changes proposed in this pull request:

* Add 'str_to_number' attribute for Num2Word_VI class for running
such command-line command `num2words 125 -l vi`.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* Run command-line command `num2words 439.25 -l vi` after the package installation.