### PR TITLE
Fix Num2Word_ID not inheriting Num2Word_Base

### DIFF
--- a/num2words/lang_ID.py
+++ b/num2words/lang_ID.py
@@ -17,8 +17,9 @@
 
 from __future__ import print_function, unicode_literals
 
+from .base import Num2Word_Base
 
-class Num2Word_ID():
+class Num2Word_ID(Num2Word_Base):
     BASE = {0: [],
             1: ["satu"],
             2: ["dua"],
@@ -47,10 +48,10 @@ class Num2Word_ID():
     errmsg_toobig = "Too large"
     max_num = 10 ** 36
 
-    def split_by_koma(self, number):
+    def split_by_comma(self, number):
         return str(number).split('.')
 
-    def split_by_3(self, number):
+    def split_by_three(self, number):
         """
         starting here, it groups the number by three from the tail
         '1234567' -> (('1',),('234',),('567',))
@@ -175,10 +176,10 @@ class Num2Word_ID():
         if number < 0:
             minus = 'min '
         float_word = ''
-        n = self.split_by_koma(abs(number))
+        n = self.split_by_comma(abs(number))
         if len(n) == 2:
             float_word = self.spell_float(n[1])
-        return minus + self.join(self.spell(self.split_by_3(n[0])), float_word)
+        return minus + self.join(self.spell(self.split_by_three(n[0])), float_word)
 
     def to_ordinal(self, number):
         self.verify_ordinal(number)

--- a/tests/test_id.py
+++ b/tests/test_id.py
@@ -51,6 +51,20 @@ class Num2WordsIDTest(TestCase):
             num2words(-0.234, lang='id'), "min nol koma dua tiga empat"
         )
 
+    def test_to_currency(self):
+        self.assertEqual(
+            num2words('110000', lang='id', to='currency'),
+            "seratus sepuluh ribu rupiah"
+        )
+        self.assertEqual(
+            num2words('9023110000', lang='id', to='currency'),
+            "sembilan miliar dua puluh tiga juta seratus sepuluh ribu rupiah"
+        )
+        self.assertEqual(
+            num2words(0, lang='id', to='currency'),
+            "nol rupiah"
+        )
+
     def test_ordinal_for_natural_number(self):
         self.assertEqual(num2words(1, ordinal=True, lang='id'), "pertama")
         self.assertEqual(num2words(10, ordinal=True, lang='id'), "kesepuluh")


### PR DESCRIPTION
### Changes proposed in this pull request:

* Fix Num2Word_ID not inherting Num2Word_Base, this causes the converter to break if a String is passed.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Added an extra testcase with a String passed to the library to ensure it won't happened again in the future.

```bash
$ python3 -m unittest tests/test_id.py
.......
----------------------------------------------------------------------
Ran 7 tests in 0.001s

OK
```