### PR TITLE
optimize the regex to transform German cardinal numbers to ordinal nu…

### DIFF
--- a/num2words/lang_DE.py
+++ b/num2words/lang_DE.py
@@ -129,14 +129,9 @@ class Num2Word_DE(Num2Word_EU):
         if res == "eintausendste" or res == "einhundertste":
             res = res.replace("ein", "", 1)
         # ... similarly for "millionste" etc.
-        res = re.sub(r'eine ([a-z]+(illion|illiard)ste)$',
-                     lambda m: m.group(1), res)
         # Ordinals involving "Million" etc. are written without a space.
         # see https://de.wikipedia.org/wiki/Million#Sprachliches
-        res = re.sub(r' ([a-z]+(illion|illiard)ste)$',
-                     lambda m: m.group(1), res)
-
-        return res
+        return re.sub(r'(?:eine)? ([a-z]+(illion|illiard)ste)$', r'\1', res)
 
     def to_ordinal_num(self, value):
         self.verify_ordinal(value)


### PR DESCRIPTION
## Optimize performance of the German ordinal numbers

### Changes proposed in this pull request:

* move the two regexes into one
* use `r'\1'` instead of the `m.group(1)`, which is likely more efficient and more elegant.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Test if the ordinal numbers still work