### PR TITLE
lang_LT.py: correction

### DIFF
--- a/num2words/lang_LT.py
+++ b/num2words/lang_LT.py
@@ -79,10 +79,10 @@ THOUSANDS = {
     4: ('trilijonas', 'trilijonai', 'trilijonų'),
     5: ('kvadrilijonas', 'kvadrilijonai', 'kvadrilijonų'),
     6: ('kvintilijonas', 'kvintilijonai', 'kvintilijonų'),
-    7: ('sikstilijonas', 'sikstilijonai', 'sikstilijonų'),
+    7: ('sekstilijonas', 'sekstilijonai', 'sekstilijonų'),
     8: ('septilijonas', 'septilijonai', 'septilijonų'),
     9: ('oktilijonas', 'oktilijonai', 'oktilijonų'),
-    10: ('naintilijonas', 'naintilijonai', 'naintilijonų'),
+    10: ('nonilijonas', 'nonilijonai', 'nonilijonų'),
 }
 
 GENERIC_CENTS = ('centas', 'centai', 'centų')


### PR DESCRIPTION
It seems as though someone was misled by the English words <i>six</i> and <i>nine</i> (or <i>sixty</i> and <i>ninety</i>) to form <i>sixtilijonas</i> and <i>naintilijonas</i>. It would be correct to say <i>s**e**kstilijonas</i> (from Latin <i>sextus</i> ‘sixth’) and <i>nonilijonas</i> (from Latin <i>nonus</i> ‘ninth’), compare with the English terms <i>sextillion</i> and <i>nonillion</i>.

This is already corrected in the Lithuanian Wiktionary:

https://lt.wiktionary.org/wiki/sekstilijonas
https://lt.wiktionary.org/wiki/nonilijonas