### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,7 @@ Besides the numerical argument, there are two main optional arguments.
 * ``th`` (Thai)
 * ``vi`` (Vietnamese)
 * ``nl`` (Dutch)
-* ``uk`` (Ukrainian)
+* ``ukr`` (Ukrainian)
 
 You can supply values like ``fr_FR``; if the country doesn't exist but the
 language does, the code will fall back to the base language (i.e. ``fr``). If


### PR DESCRIPTION
Edited 'ukr' for Ukrainian lang instead of 'uk', now it works.

## Fixes # by...

### Changes proposed in this pull request:

* ...
* ...

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

*Fill out this section so that a reviewer can know how to verify your change.*
Try num2words(1, lang='ukr', to='currency')

### Additional notes

*If applicable, explain the rationale behind your change.*
'uk' didn't work, 'ukr' did