### PR TITLE
Correct the Dutch ordinal for zero from 'nule' to 'nulde'

### DIFF
--- a/num2words/lang_NL.py
+++ b/num2words/lang_NL.py
@@ -76,7 +76,8 @@ class Num2Word_NL(Num2Word_EU):
                              "zes", "vijf", "vier", "drie", "twee", "één",
                              "nul"]
 
-        self.ords = {"één": "eerst",
+        self.ords = {"nul": "nuld",
+                     "één": "eerst",
                      "twee": "tweed",
                      "drie": "derd",
                      "vier": "vierd",


### PR DESCRIPTION
## Fixes # by...
Sander Eikelenboom <oss@applied-machinelearning.eu>

### Changes proposed in this pull request:
Correct the Dutch ordinal for zero from 'nule' to 'nulde'

### Status
- [X] READY
- [ ] HOLD
- [] WIP (Work-In-Progress)

### How to verify this change
https://en.wiktionary.org/wiki/nulde#Dutch