### PR TITLE
Fix ordinal_num output for Dutch (NL)

### DIFF
--- a/num2words/lang_NL.py
+++ b/num2words/lang_NL.py
@@ -135,7 +135,7 @@ class Num2Word_NL(Num2Word_EU):
 
     def to_ordinal_num(self, value):
         self.verify_ordinal(value)
-        return str(value) + "."
+        return str(value) + "e"
 
     def pluralize(self, n, forms):
         """


### PR DESCRIPTION
### Changes proposed in this pull request:

Current output outputs essentially german style Ordinal numeric output (with the dot `.`)
This has been changed for the Dutch language to use `e` instead.


### Status

 - [X] READY
 - [ ] HOLD
 - [ ] WIP (Work-In-Progress)

### How to verify this change

All numbers in Dutch use a `e` suffix for their ordinal numerical form.

So everywhere that had `.` needs to have `e`.

### Additional notes

In Dutch we use `e` or with Unicode available either `ᴱ` or `ᵉ`.

So `1e`, `1ᴱ`, `1ᵉ` for example. For now I just put the standard `e` in there, but all could work.