### PR TITLE
Patch for output from 31+ digit numbers as strings

### DIFF
--- a/num2words/base.py
+++ b/num2words/base.py
@@ -19,7 +19,7 @@ from __future__ import unicode_literals
 
 import math
 from collections import OrderedDict
-from decimal import Decimal
+from decimal import Decimal, getcontext
 
 from .compat import to_s
 from .currency import parse_currency_parts, prefix_currency
@@ -66,6 +66,10 @@ class Num2Word_Base(object):
             self.cards[n] = word
 
     def splitnum(self, value):
+        oldcontext = getcontext().prec
+        if isinstance(value, Decimal):
+            getcontext().prec = len(str(value))
+
         for elem in self.cards:
             if elem > value:
                 continue
@@ -88,6 +92,7 @@ class Num2Word_Base(object):
             if mod:
                 out.append(self.splitnum(mod))
 
+            getcontext().prec = oldcontext
             return out
 
     def parse_minus(self, num_str):

--- a/tests/test_en.py
+++ b/tests/test_en.py
@@ -178,3 +178,8 @@ class Num2WordsENTest(TestCase):
                          'sixty-six m.y.a.')
         self.assertEqual(num2words(-66000000, lang='en', to='year'),
                          'sixty-six million BC')
+
+    def test_large_numbers(self):
+        # Verify integers and strings produce same output.
+        for i in (1, 100, 200, 306):
+            self.assertEqual(num2words(int('9' * i)), num2words(str('9' * i)))


### PR DESCRIPTION
Had to open a new PR. Again, my apologies.

This patch is for numbers passed into the `num2words` library as strings containing 31 or more digits. Included is also a test for it.