### PR TITLE
Adding possibility to convert "point zero". e.g. "3.0" now converts i…

### DIFF
--- a/num2words/base.py
+++ b/num2words/base.py
@@ -21,7 +21,7 @@ import math
 from collections import OrderedDict
 from decimal import Decimal
 
-from .compat import to_s
+from .compat import to_s, represents_int
 from .currency import parse_currency_parts, prefix_currency
 
 
@@ -102,7 +102,7 @@ class Num2Word_Base(object):
 
     def to_cardinal(self, value):
         try:
-            assert int(value) == value
+            assert represents_int(value.__str__())
         except (ValueError, TypeError, AssertionError):
             return self.to_cardinal_float(value)
 

--- a/num2words/compat.py
+++ b/num2words/compat.py
@@ -27,3 +27,11 @@ def to_s(val):
         return unicode(val)
     except NameError:
         return str(val)
+
+
+def represents_int(s):
+    try:
+        int(s)
+        return True
+    except ValueError:
+        return False


### PR DESCRIPTION
### Changes proposed in this pull request:

Adding possibility to convert "point zero" at the end of a decimal. 
e.g. "3.0" now converts to "three point zero"

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

```
>>> from num2words import num2words
>>> num2words('3.0')
'three point zero'
```