### PR TITLE
Omit cents when zero by passing verbose_subunits=False

### DIFF
--- a/num2words/base.py
+++ b/num2words/base.py
@@ -264,7 +264,7 @@ class Num2Word_Base(object):
         return "%02d" % number
 
     def to_currency(self, val, currency='EUR', cents=True, separator=',',
-                    adjective=False, verbose_decimal=True):
+                    adjective=False, verbose_subunits=True):
         """
         Args:
             val: Numeric value
@@ -272,7 +272,7 @@ class Num2Word_Base(object):
             cents (bool): Verbose cents
             separator (str): Cent separator
             adjective (bool): Prefix currency name with adjective
-            verbose_decimal (bool): Append cents regardless of whether cents > 0
+            verbose_subunits (bool): Append cents regardless of whether cents > 0
         Returns:
             str: Formatted string
 
@@ -294,7 +294,7 @@ class Num2Word_Base(object):
         cents_str = self._cents_verbose(right, currency) \
             if cents else self._cents_terse(right, currency)
 
-        if verbose_decimal or right > 0:
+        if verbose_subunits or right > 0:
             return u'%s%s %s%s %s %s' % (
                 minus_str,
                 self.to_cardinal(left),

--- a/num2words/base.py
+++ b/num2words/base.py
@@ -264,7 +264,7 @@ class Num2Word_Base(object):
         return "%02d" % number
 
     def to_currency(self, val, currency='EUR', cents=True, separator=',',
-                    adjective=False):
+                    adjective=False, verbose_decimal=True):
         """
         Args:
             val: Numeric value
@@ -272,6 +272,7 @@ class Num2Word_Base(object):
             cents (bool): Verbose cents
             separator (str): Cent separator
             adjective (bool): Prefix currency name with adjective
+            verbose_decimal (bool): Append cents regardless of whether cents > 0
         Returns:
             str: Formatted string
 
@@ -293,14 +294,21 @@ class Num2Word_Base(object):
         cents_str = self._cents_verbose(right, currency) \
             if cents else self._cents_terse(right, currency)
 
-        return u'%s%s %s%s %s %s' % (
-            minus_str,
-            self.to_cardinal(left),
-            self.pluralize(left, cr1),
-            separator,
-            cents_str,
-            self.pluralize(right, cr2)
-        )
+        if verbose_decimal or right > 0:
+            return u'%s%s %s%s %s %s' % (
+                minus_str,
+                self.to_cardinal(left),
+                self.pluralize(left, cr1),
+                separator,
+                cents_str,
+                self.pluralize(right, cr2)
+            )
+        else:
+            return u'%s%s %s' % (
+                minus_str,
+                self.to_cardinal(left),
+                self.pluralize(left, cr1)
+            )
 
     def setup(self):
         pass

--- a/num2words/lang_SR.py
+++ b/num2words/lang_SR.py
@@ -174,7 +174,7 @@ class Num2Word_SR(Num2Word_Base):
         return ' '.join(words)
 
     def to_currency(self, val, currency='EUR', cents=True, separator=',',
-                    adjective=False):
+                    adjective=False, verbose_decimal=True):
         """
         Args:
             val: Numeric value
@@ -182,6 +182,7 @@ class Num2Word_SR(Num2Word_Base):
             cents (bool): Verbose cents
             separator (str): Cent separator
             adjective (bool): Prefix currency name with adjective
+            verbose_decimal (bool): Append cents regardless of whether cents > 0
         Returns:
             str: Formatted string
 
@@ -205,12 +206,18 @@ class Num2Word_SR(Num2Word_Base):
         minus_str = "%s " % self.negword if is_negative else ""
         cents_str = self._cents_verbose(right, currency) \
             if cents else self._cents_terse(right, currency)
-
-        return u'%s%s %s%s %s %s' % (
-            minus_str,
-            self.to_cardinal(left, feminine=cr1[-1]),
-            self.pluralize(left, cr1),
-            separator,
-            cents_str,
-            self.pluralize(right, cr2)
-        )
+        if verbose_decimal or right > 0:
+            return u'%s%s %s%s %s %s' % (
+                minus_str,
+                self.to_cardinal(left, feminine=cr1[-1]),
+                self.pluralize(left, cr1),
+                separator,
+                cents_str,
+                self.pluralize(right, cr2)
+            )
+        else:
+            return u'%s%s %s' % (
+                minus_str,
+                self.to_cardinal(left, feminine=cr1[-1]),
+                self.pluralize(left, cr1)
+            )

--- a/num2words/lang_SR.py
+++ b/num2words/lang_SR.py
@@ -174,7 +174,7 @@ class Num2Word_SR(Num2Word_Base):
         return ' '.join(words)
 
     def to_currency(self, val, currency='EUR', cents=True, separator=',',
-                    adjective=False, verbose_decimal=True):
+                    adjective=False, verbose_subunits=True):
         """
         Args:
             val: Numeric value
@@ -182,7 +182,7 @@ class Num2Word_SR(Num2Word_Base):
             cents (bool): Verbose cents
             separator (str): Cent separator
             adjective (bool): Prefix currency name with adjective
-            verbose_decimal (bool): Append cents regardless of whether cents > 0
+            verbose_subunits (bool): Append cents regardless of whether cents > 0
         Returns:
             str: Formatted string
 
@@ -206,7 +206,7 @@ class Num2Word_SR(Num2Word_Base):
         minus_str = "%s " % self.negword if is_negative else ""
         cents_str = self._cents_verbose(right, currency) \
             if cents else self._cents_terse(right, currency)
-        if verbose_decimal or right > 0:
+        if verbose_subunits or right > 0:
             return u'%s%s %s%s %s %s' % (
                 minus_str,
                 self.to_cardinal(left, feminine=cr1[-1]),

--- a/tests/test_en.py
+++ b/tests/test_en.py
@@ -127,7 +127,7 @@ class Num2WordsENTest(TestCase):
 
         self.assertEqual(
             num2words('2000.00', lang='en', to='currency', separator=' and',
-                      cents=True, currency='MXN', verbose_decimal=False),
+                      cents=True, currency='MXN', verbose_subunits=False),
             "two thousand pesos"
         )
 

--- a/tests/test_en.py
+++ b/tests/test_en.py
@@ -126,6 +126,12 @@ class Num2WordsENTest(TestCase):
         )
 
         self.assertEqual(
+            num2words('2000.00', lang='en', to='currency', separator=' and',
+                      cents=True, currency='MXN', verbose_decimal=False),
+            "two thousand pesos"
+        )
+
+        self.assertEqual(
             num2words('4.01', lang='en', to='currency', separator=' and',
                       cents=True, currency='MXN'),
             "four pesos and one cent"

--- a/tests/test_sr.py
+++ b/tests/test_sr.py
@@ -241,3 +241,8 @@ class Num2WordsSRTest(TestCase):
             num2words('38.4', lang='sr', to='currency', separator=' i',
                       cents=False, currency='EUR'),
         )
+        self.assertEqual(
+            "trideset osam evra",
+            num2words('38', lang='sr', to='currency', separator=' i',
+                      cents=False, currency='EUR', verbose_decimal=False),
+        )

--- a/tests/test_sr.py
+++ b/tests/test_sr.py
@@ -244,5 +244,5 @@ class Num2WordsSRTest(TestCase):
         self.assertEqual(
             "trideset osam evra",
             num2words('38', lang='sr', to='currency', separator=' i',
-                      cents=False, currency='EUR', verbose_decimal=False),
+                      cents=False, currency='EUR', verbose_subunits=False),
         )


### PR DESCRIPTION
### Changes proposed in this pull request:

#### With verbose_subunits=True (DEFAULT):
one hundred and twenty-three rupees and zero paise

#### With verbose_subunits=False:
one hundred and twenty-three rupees

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

**

### Additional notes

*Invoices in India must not specify paisa (INR subunits) when subunits are zero.*
