### PR TITLE
Fixed issue #402 negative values between minus one to zero not negative

### DIFF
--- a/num2words/base.py
+++ b/num2words/base.py
@@ -100,7 +100,7 @@ class Num2Word_Base(object):
     def str_to_number(self, value):
         return Decimal(value)
 
-    def to_cardinal(self, value, negative_value_flag = False):
+    def to_cardinal(self, value, negative_value_flag=False):
         try:
             assert int(value) == value
         except (ValueError, TypeError, AssertionError):

--- a/num2words/base.py
+++ b/num2words/base.py
@@ -100,14 +100,14 @@ class Num2Word_Base(object):
     def str_to_number(self, value):
         return Decimal(value)
 
-    def to_cardinal(self, value):
+    def to_cardinal(self, value, negative_value_flag = False):
         try:
             assert int(value) == value
         except (ValueError, TypeError, AssertionError):
             return self.to_cardinal_float(value)
 
         out = ""
-        if value < 0:
+        if value < 0 or negative_value_flag == True:
             value = abs(value)
             out = self.negword
 
@@ -142,12 +142,18 @@ class Num2Word_Base(object):
         except (ValueError, TypeError, AssertionError, AttributeError):
             raise TypeError(self.errmsg_nonnum % value)
 
+        # adding following condition to handle all negative float values including values between -1 to 0 for example "-0.01"
+        negative_value_flag = False
+        if value < 0:
+            value = abs(value)
+            negative_value_flag = True
+
         pre, post = self.float2tuple(float(value))
 
         post = str(post)
         post = '0' * (self.precision - len(post)) + post
 
-        out = [self.to_cardinal(pre)]
+        out = [self.to_cardinal(pre, negative_value_flag)]
         if self.precision:
             out.append(self.title(self.pointword))
 


### PR DESCRIPTION
## Fixes # by...
Rohan Dudam
### Changes proposed in this pull request:

* Fixed issue #402 
* the root cause of this issue is line https://github.com/savoirfairelinux/num2words/blob/master/num2words/base.py#L122. It converting negative values between (-1,0) to 0 while parsing the pre-value of float. for example value (-0.01) get converted into "0". Here, the expectation is to achieve "-0" which is not possible. That's why it displaying the wrong value. 
* To fix it, handled all negative float values separately under base page "to_cardinal_float" method.
### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

*.Test the changes with few positive and negative integer and float values (especially with values between (-1,0))
`import num2words
num2words.num2words(-0.01)
# 'minus zero point zero one'`
