### PR TITLE
Fixed: Tests fail on Windows #401 

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,12 +59,12 @@ class CliTestCase(unittest.TestCase):
         output = self.cli.run_cmd('--list-languages')
         self.assertEqual(
             sorted(list(num2words.CONVERTER_CLASSES.keys())),
-            output.out.strip().split(os.linesep)
+            output.out.strip().split()
         )
         output = self.cli.run_cmd('-L')
         self.assertEqual(
             sorted(list(num2words.CONVERTER_CLASSES.keys())),
-            output.out.strip().split(os.linesep)
+            output.out.strip().split()
         )
 
     def test_cli_list_converters(self):
@@ -73,12 +73,12 @@ class CliTestCase(unittest.TestCase):
         output = self.cli.run_cmd('--list-converters')
         self.assertEqual(
             sorted(list(num2words.CONVERTES_TYPES)),
-            output.out.strip().split(os.linesep)
+            output.out.strip().split()
         )
         output = self.cli.run_cmd('-C')
         self.assertEqual(
             sorted(list(num2words.CONVERTES_TYPES)),
-            output.out.strip().split(os.linesep)
+            output.out.strip().split()
         )
 
     def test_cli_default_lang(self):


### PR DESCRIPTION


## Fixes # by Zelinskiy-Aleksandr

### Changes proposed in this pull request:

* Fixed issue  [Tests fail on Windows #401](https://github.com/savoirfairelinux/num2words/issues/401) 
*  os.linesep returns '\r\n' on Windows but delegator.py returns  '\n\n'.
   os.linesep was removed for CLI tests (tests/test_cli.py)
   Linux also uses \n as line separator.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

*Run tests (python setup.py test) on Windows or Linux platforms*


