### PR TITLE
[ADD] num2words: add support to translate some currencies in italian language

### DIFF
--- a/num2words/lang_IT.py
+++ b/num2words/lang_IT.py
@@ -16,6 +16,8 @@
 
 from __future__ import unicode_literals
 
+from .lang_EU import Num2Word_EU
+
 # Globals
 # -------
 
@@ -43,56 +45,26 @@ EXPONENT_PREFIXES = [
 ]
 
 
-# Utils
-# =====
-
-def phonetic_contraction(string):
-    return (string
-            .replace("oo", "o")  # ex. "centootto"
-            .replace("ao", "o")  # ex. "settantaotto"
-            .replace("io", "o")  # ex. "ventiotto"
-            .replace("au", "u")  # ex. "trentauno"
-            .replace("iu", "u")  # ex. "ventiunesimo"
-            )
-
-
-def exponent_length_to_string(exponent_length):
-    # We always assume `exponent` to be a multiple of 3. If it's not true, then
-    # Num2Word_IT.big_number_to_cardinal did something wrong.
-    prefix = EXPONENT_PREFIXES[exponent_length // 6]
-    if exponent_length % 6 == 0:
-        return prefix + "ilione"
-    else:
-        return prefix + "iliardo"
-
-
-def accentuate(string):
-    # This is inefficient: it may do several rewritings when deleting
-    # half-sentence accents. However, it is the easiest method and speed is
-    # not crucial (duh), so...
-    return " ".join(
-        # Deletes half-sentence accents and accentuates the last "tre"
-        [w.replace("tré", "tre")[:-3] + "tré"
-         # We shouldn't accentuate a single "tre": is has to be a composite
-         # word.                ~~~~~~~~~~
-         if w[-3:] == "tre" and len(w) > 3
-         # Deletes half-sentence accents anyway
-         #     ~~~~~~~~~~~~~~~~~~~~~~
-         else w.replace("tré", "tre")
-         for w in string.split()
-         ])
-
-
-def omitt_if_zero(number_to_string):
-    return "" if number_to_string == ZERO else number_to_string
+GENERIC_DOLLARS = ('dollaro', 'dollari')
+GENERIC_CENTS = ('centesimo', 'centesimi')
+CURRENCIES_UNA = ('GBP')
 
 
 # Main class
 # ==========
 
-class Num2Word_IT:
+class Num2Word_IT(Num2Word_EU):
+    CURRENCY_FORMS = {
+        'EUR': (('euro', 'euro'), GENERIC_CENTS),
+        'USD': (GENERIC_DOLLARS, GENERIC_CENTS),
+        'GBP': (('sterlina', 'sterline'), ('penny', 'penny')),
+        'CNY': (('yuan', 'yuan'), ('fen', 'fen')),
+    }
     MINUS_PREFIX_WORD = "meno "
     FLOAT_INFIX_WORD = " virgola "
+
+    def setup(self):
+        Num2Word_EU.setup(self)
 
     def __init__(self):
         pass
@@ -206,3 +178,64 @@ class Num2Word_IT:
             if string[-3:] == "mil":
                 string += "l"
             return string + "esimo"
+
+    def to_currency(self, val, currency='EUR', cents=True, separator=' e',
+                    adjective=False):
+        result = super(Num2Word_IT, self).to_currency(
+            val, currency=currency, cents=cents, separator=separator,
+            adjective=adjective)
+        # Handle exception. In italian language is "un euro",
+        # "un dollaro" etc. (not "uno euro", "uno dollaro").
+        # There is an exception, some currencies need "una":
+        # e.g. "una sterlina"
+        if currency in CURRENCIES_UNA:
+            list_result = result.split(" ")
+            if list_result[0] == "uno":
+                list_result[0] = list_result[0].replace("uno", "una")
+                result = " ".join(list_result)
+        result = result.replace("uno", "un")
+        return result
+
+# Utils
+# =====
+
+
+def phonetic_contraction(string):
+    return (string
+            .replace("oo", "o")  # ex. "centootto"
+            .replace("ao", "o")  # ex. "settantaotto"
+            .replace("io", "o")  # ex. "ventiotto"
+            .replace("au", "u")  # ex. "trentauno"
+            .replace("iu", "u")  # ex. "ventiunesimo"
+            )
+
+
+def exponent_length_to_string(exponent_length):
+    # We always assume `exponent` to be a multiple of 3. If it's not true, then
+    # Num2Word_IT.big_number_to_cardinal did something wrong.
+    prefix = EXPONENT_PREFIXES[exponent_length // 6]
+    if exponent_length % 6 == 0:
+        return prefix + "ilione"
+    else:
+        return prefix + "iliardo"
+
+
+def accentuate(string):
+    # This is inefficient: it may do several rewritings when deleting
+    # half-sentence accents. However, it is the easiest method and speed is
+    # not crucial (duh), so...
+    return " ".join(
+        # Deletes half-sentence accents and accentuates the last "tre"
+        [w.replace("tré", "tre")[:-3] + "tré"
+         # We shouldn't accentuate a single "tre": is has to be a composite
+         # word.                ~~~~~~~~~~
+         if w[-3:] == "tre" and len(w) > 3
+         # Deletes half-sentence accents anyway
+         #     ~~~~~~~~~~~~~~~~~~~~~~
+         else w.replace("tré", "tre")
+         for w in string.split()
+         ])
+
+
+def omitt_if_zero(number_to_string):
+    return "" if number_to_string == ZERO else number_to_string

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -21,6 +21,36 @@ from unittest import TestCase
 
 from num2words import num2words
 
+TEST_CASES_TO_CURRENCY_EUR = (
+    (1.00, 'un euro e zero centesimi'),
+    (2.01, 'due euro e un centesimo'),
+    (8.10, 'otto euro e dieci centesimi'),
+    (12.26, 'dodici euro e ventisei centesimi'),
+    (21.29, 'ventun euro e ventinove centesimi'),
+    (81.25, 'ottantun euro e venticinque centesimi'),
+    (100.00, 'cento euro e zero centesimi'),
+)
+
+TEST_CASES_TO_CURRENCY_USD = (
+    (1.00, 'un dollaro e zero centesimi'),
+    (2.01, 'due dollari e un centesimo'),
+    (8.10, 'otto dollari e dieci centesimi'),
+    (12.26, 'dodici dollari e ventisei centesimi'),
+    (21.29, 'ventun dollari e ventinove centesimi'),
+    (81.25, 'ottantun dollari e venticinque centesimi'),
+    (100.00, 'cento dollari e zero centesimi'),
+)
+
+TEST_CASES_TO_CURRENCY_GBP = (
+    (1.00, 'una sterlina e zero penny'),
+    (2.01, 'due sterline e un penny'),
+    (8.10, 'otto sterline e dieci penny'),
+    (12.26, 'dodici sterline e ventisei penny'),
+    (21.29, 'ventun sterline e ventinove penny'),
+    (81.25, 'ottantun sterline e venticinque penny'),
+    (100.00, 'cento sterline e zero penny'),
+)
+
 
 class Num2WordsITTest(TestCase):
     maxDiff = None
@@ -240,3 +270,24 @@ class Num2WordsITTest(TestCase):
         self.assertAlmostEqual(
             num2words(1.1, lang="it"), "uno virgola uno"
         )
+
+    def test_currency_eur(self):
+        for test in TEST_CASES_TO_CURRENCY_EUR:
+            self.assertEqual(
+                num2words(test[0], lang='it', to='currency', currency='EUR'),
+                test[1]
+            )
+
+    def test_currency_usd(self):
+        for test in TEST_CASES_TO_CURRENCY_USD:
+            self.assertEqual(
+                num2words(test[0], lang='it', to='currency', currency='USD'),
+                test[1]
+            )
+
+    def test_currency_gbp(self):
+        for test in TEST_CASES_TO_CURRENCY_GBP:
+            self.assertEqual(
+                num2words(test[0], lang='it', to='currency', currency='GBP'),
+                test[1]
+            )


### PR DESCRIPTION
### Changes proposed in this pull request:

* Adding support for italian translation of some currencies (to_currency)
* Tests for italian language currencies

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change
```
lang='it'                                                                                     
var1 = '49.95'                                                                                                                                 
var2 = '1.01'                                                                              
b = num2words(var1, lang=lang, to='currency', currency='USD')
print(b)                                                               
d = num2words(var2, lang=lang, to='currency', currency='EUR')
print(d) 
```
