### PR TITLE
EURO removed from the list of languages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,6 @@ Besides the numerical argument, there are two main optional arguments.
 * ``es`` (Spanish)
 * ``es_CO`` (Spanish - Colombia)
 * ``es_VE`` (Spanish - Venezuela)
-* ``eu`` (EURO)
 * ``fi`` (Finnish)
 * ``fr`` (French)
 * ``fr_CH`` (French - Switzerland)


### PR DESCRIPTION
I don't know if the language list is generated automatically from the language files, but the currency conversion EURO file is showing up in the list of languages. Additionally the eu language code belongs to Euskara (Basque language), so as a minor change I have removed the eu lang from the list.

## Fixes # by...

### Changes proposed in this pull request:

* ...
* ...

### Status

- [ ] READY
- [ ] HOLD
- [X] WIP (Work-In-Progress)

### How to verify this change

*Fill out this section so that a reviewer can know how to verify your change.*

### Additional notes

*If applicable, explain the rationale behind your change.*

