### PR TITLE
improved how the numbers 100 and 1000 should be written in norwegian …

### DIFF
--- a/num2words/lang_NO.py
+++ b/num2words/lang_NO.py
@@ -71,6 +71,10 @@ class Num2Word_NO(lang_EU.Num2Word_EU):
             return (rtext, rnum)
         elif 100 > lnum > rnum:
             return ("%s-%s" % (ltext, rtext), lnum + rnum)
+        elif rnum == 100 and lnum == 1:
+            return ("%s" % (rtext), rnum)
+        elif rnum == 1000 and lnum == 1:
+            return ("%s" % (rtext), rnum)
         elif lnum >= 100 > rnum:
             return ("%s og %s" % (ltext, rtext), lnum + rnum)
         elif rnum > lnum:


### PR DESCRIPTION
…bokmål

## Fixes # by...

Ørjan Vøllestad

### Changes proposed in this pull request:

* adding two special cases to the merge function, for the numbers 100 and 1000.

### Status

- [X ] READY
- [ ] HOLD
- [] WIP (Work-In-Progress)

### How to verify this change

*Fill out this section so that a reviewer can know how to verify your change.*

### Additional notes

*If applicable, explain the rationale behind your change.*

In norwegian, you shoud not write 100 as "en hundre". It should be either "ett hundre" or simply "hundre", which is the recommended way, see: https://www.riksmalsforbundet.no/qa_faqs/ett-hundretusen/

The same goes for 1000. 