### PR TITLE
Update test_de.py: "eine Mark" in TEST_CASES_TO_CURRENCY_DEM

### DIFF
--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -52,7 +52,7 @@ TEST_CASES_TO_CURRENCY_GBP = (
 )
 
 TEST_CASES_TO_CURRENCY_DEM = (
-    (1.00, 'ein Mark und null Pfennig'),
+    (1.00, 'eine Mark und null Pfennig'), # in contrast to Euro, Dollar & Pound, "die Mark" is feminine
     (2.01, 'zwei Mark und ein Pfennig'),
     (8.10, 'acht Mark und zehn Pfennig'),
     (12.26, 'zwölf Mark und sechsundzwanzig Pfennig'),


### PR DESCRIPTION
TEST_CASES_TO_CURRENCY_DEM [1.00] = 'eine Mark und null Pfennig' 
## in contrast to Euro, Dollar & Pound, "die Mark" is feminine

## Fixes issue #462  by @rillig (Roland Illig)

### Changes proposed in this pull request:

* in test_de.py : TEST_CASES_TO_CURRENCY_DEM [1.00] = 'eine Mark und null Pfennig' 

* maybe add other test cases :  201.50 => "zweihunderteine Mark und fünfzig Pfennig", idem for 1001.xx, 1 000 001,xx DEM
* check whether more has to be done for amounts = 1 (mod 100) (when truncated: e.g., also for 201.50 DEM)
* in function num2words(), for currency "DEM" make the necessary change

### Status

- [ ] READY
- [ ] HOLD
- [X] WIP (Work-In-Progress)

### How to verify this change

run test_de.py (after fix in num2words / currency = 'DEM'.

### Additional notes

See issue #462 : "Mark" is feminie, it must be "eine Mark", not "ein Mark"