### PR TITLE
Update lang_DE:  in to_currency "eine " for Mark(DEM) & Lira (ITL)

### DIFF
--- a/num2words/lang_DE.py
+++ b/num2words/lang_DE.py
@@ -147,8 +147,10 @@ class Num2Word_DE(Num2Word_EU):
         result = super(Num2Word_DE, self).to_currency(
             val, currency=currency, cents=cents, separator=separator,
             adjective=adjective)
-        # Handle exception, in german is "ein Euro" and not "eins Euro"
-        return result.replace("eins ", "ein ")
+        # Handle exception: in German it's not "eins Euro" but "ein Euro"
+        # (also for USD & other "Dollar", CHF & other Franken, cent, Pfennig...) but "eine Mark" for DEM
+        # See also issue #462 and patch #469
+        return result.replace("eins ", "eine " if currency in ("DEM","ITL") else "ein ")
 
     def to_year(self, val, longval=True):
         if not (val // 100) % 10:


### PR DESCRIPTION
Currently, the "exception handling" in to_currency() replaces "...eins " by "...ein " which is correct for Euro, Dollar, Franken, cents, Pfennig, but it must be "...eine " for Mark (DEM, other Marks?) and for ital. Lira (ITL), maybe others ("Sesterze" doesn't exist any more, but....)?
See.

## Fixes issue #462 reported by @rillig and patch #469 of the test cases.

### Changes proposed in this pull request:

* replace "eins " by "ein " as it is done now unless currency is "DEM" or "ITL" in which case it must be "eine "

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Run test cases (including patch #469 by @m-f-h !), see there for more info

### Additional notes

See also issue #462 reported by @rillig
For the moment I "hard-wired" DEM and ITL (Italian Lira) which are feminine and therefore require "eine", not "ein" in German.
Maybe one could use ` if currency in FEMININE_CURRENCIES ` and define a set or tuple `FEMININE_CURRENCIES = {"DEM","ITL"}, esp. if there are more to come.