### PR TITLE
Update test_de.py : "ein Mark" => "eine Mark"

### DIFF
--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -52,7 +52,7 @@ TEST_CASES_TO_CURRENCY_GBP = (
 )
 
 TEST_CASES_TO_CURRENCY_DEM = (
-    (1.00, 'ein Mark und null Pfennig'),
+    (1.00, 'eine Mark und null Pfennig'),
     (2.01, 'zwei Mark und ein Pfennig'),
     (8.10, 'acht Mark und zehn Pfennig'),
     (12.26, 'zwölf Mark und sechsundzwanzig Pfennig'),


### PR DESCRIPTION
## Test conforming to issue #462 fixed in patch #470 

In currencies, 1, 101, 201, ... 1000 001 become "eine", not "ein" for feminine currencies like "Mark" (in DEM, FIM) and "Lira" (in Italian ITL, Turkish TRY and Syrian DMG)

## Fixes #462 by @rillig

### Changes proposed in this pull request:

* change the only affected test, "1.00 DEM" => "eine Mark" (as now correctly produced by to_currency() in lang_de.py) instead of wrong "ein Mark"

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

This is itself the test case, it said "1.00 DEM" should become "ein Mark", but the correct result is "eine Mark", now produced (after patch #470) by to_currency() (overloaded in lang_de.py)

### Additional notes

Should now also give correct results for other "Mark" and "Lira", esp. Turkish Lira (TRY) and Syrian Lira (or pound)
