### PR TITLE
update test_fr_be.py : 10**6-th = millionième, no "-s-"

### DIFF
--- a/tests/test_fr_ch.py
+++ b/tests/test_fr_ch.py
@@ -50,9 +50,9 @@ TEST_CASES_ORDINAL = (
     (28, 'vingt-huitième'),
     (100, 'centième'),
     (1000, 'millième'),
-    (1000000, 'un millionsième'),
-    (1000000000000000, 'un billiardsième'),
-    (1000000000000000000, 'un trillionsième')  # over 1e18 is not supported
+    (1000000, 'un millionième'),  # Réf: https://www.dictionnaire-academie.fr/article/A9M2188
+    (1000000000000000, 'un billiardième'),
+    (1000000000000000000, 'un trillionième')  # over 1e18 is not supported
 )
 
 TEST_CASES_TO_CURRENCY_EUR = (


### PR DESCRIPTION
It must be "millionième" (as in test_fr.py), not "millionsième" as this test file erroneously required.
Réf.: https://www.dictionnaire-academie.fr/article/A9M2188

## Fixes # by...

### Changes proposed in this pull request:

* ordinal for 10^6, 10^9, 10^12 is "millionième" etc. (as correctly produced for lang="FR")

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

This was actually blocking PR #411 where the program correctly produces "millionième" etc. while this test case file (and test_fr_ch) required "millionsième".

### Additional notes

Réf.: https://www.dictionnaire-academie.fr/article/A9M2188
There is no source that would suggest that it be different for "fr_be" and "fr_ch", compared to "fr"