### PR TITLE
Update test_fr_ch.py

### DIFF
--- a/tests/test_fr_ch.py
+++ b/tests/test_fr_ch.py
@@ -32,8 +32,8 @@ TEST_CASES_CARDINAL = (
     (7232, 'sept mille deux cents trente-deux'),
     (8569, 'huit mille cinq cents soixante-neuf'),
     (9539, 'neuf mille cinq cents trente-neuf'),
-    (1000000, 'un millions'),
-    (1000001, 'un millions un'),
+    (1000000, 'un million'),
+    (1000001, 'un million un'),
     (4000000, 'quatre millions'),
     (10000000000000, 'dix billions'),
     (100000000000000, 'cent billions'),
@@ -50,9 +50,9 @@ TEST_CASES_ORDINAL = (
     (28, 'vingt-huitième'),
     (100, 'centième'),
     (1000, 'millième'),
-    (1000000, 'un millionsième'),
-    (1000000000000000, 'un billiardsième'),
-    (1000000000000000000, 'un trillionsième')  # over 1e18 is not supported
+    (1000000, 'un millionième'), # Ref: https://www.dictionnaire-academie.fr/article/A9M2188
+    (1000000000000000, 'un billiardième'), # Réf: https://www.dictionnaire-academie.fr/article/A9M2177
+    (1000000000000000000, 'un trillionième')  # over 1e18 is not supported
 )
 
 TEST_CASES_TO_CURRENCY_EUR = (


### PR DESCRIPTION
It must be "un million" (the -s only appears for plural cases as "deux millions")
and "millionième" (as in test_fr.py), not "millionsième" as this test file erroneously required.
Réf.: https://www.dictionnaire-academie.fr/article/A9M2188
and https://www.dictionnaire-academie.fr/article/A9M2177 (for 10^9 / 10^12)

## Fixes #409 by @m-f-h

### Changes proposed in this pull request:

* expect "millionième, milliardième, billionième, etc, without erroneous "-s-" in front of "-ième".

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

This is the test file itself, now expecting the correct results as produced by the patch #411

### Additional notes

see also
https://www.dictionnaire-academie.fr/article/A9M2188
https://www.dictionnaire-academie.fr/article/A9M2177
