### PR TITLE
Update test_de.py: "ein Mark" must be "eine Mark" instead

### DIFF
--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -52,7 +52,7 @@ TEST_CASES_TO_CURRENCY_GBP = (
 )
 
 TEST_CASES_TO_CURRENCY_DEM = (
-    (1.00, 'ein Mark und null Pfennig'),
+    (1.00, 'eine Mark und null Pfennig'),
     (2.01, 'zwei Mark und ein Pfennig'),
     (8.10, 'acht Mark und zehn Pfennig'),
     (12.26, 'zwölf Mark und sechsundzwanzig Pfennig'),


### PR DESCRIPTION
Update test_de.py: "ein Mark" must be "eine Mark" instead, cf. issue #462 and patch #471

## Fixes #462 by @rillig

### Changes proposed in this pull request:

* changed "ein Mark" to "eine Mark" in the test case ; code is fixed in #471

### Status

- [X] READY
- [ ] HOLD
- [] WIP (Work-In-Progress)

### How to verify this change

run test suite, esp. for lang = 'de' ; currency = "DEM"

### Additional notes

I tried to make more substantial changes (the same should be done for other currencies named "Mark" like FIM, ... and for currencies named "Lira" (italian ITL [replaced by EUR], Turkish TRY and Syrian DMG)
but since that didn't work out (mysterious errors) I try a minimal bug fix first.