### PR TITLE
#454: [tr] fix negative number problem

### DIFF
--- a/num2words/lang_TR.py
+++ b/num2words/lang_TR.py
@@ -124,11 +124,17 @@ class Num2Word_TR(Num2Word_Base):
 
         if not int(value) == value:
             return self.to_cardinal_float(value)
+
+        if str(value).startswith("-"):
+            pre_word, value = self.negword, float(str(value)[1:])
+        else:
+            pre_word, value = "", float(value)
+
         self.to_splitnum(value)
 
         if self.order_of_last_zero_digit >= len(self.integers_to_read[0]):
             # number like 00 and all 0s and even more, raise error
-            return wrd
+            return "%s%s" % (pre_word, wrd)
 
         if self.total_triplets_to_read == 1:
             if self.total_digits_outside_triplets == 2:
@@ -137,7 +143,7 @@ class Num2Word_TR(Num2Word_Base):
                     wrd += self.CARDINAL_TENS.get(
                         self.integers_to_read[0][0], ""
                     )
-                    return wrd
+                    return "%s%s" % (pre_word, wrd)
                 if self.order_of_last_zero_digit == 0:
                     # number like xy, read cardinal xy and return
                     wrd += self.CARDINAL_TENS.get(
@@ -146,7 +152,7 @@ class Num2Word_TR(Num2Word_Base):
                     wrd += self.CARDINAL_ONES.get(
                         self.integers_to_read[0][1], ""
                     )
-                return wrd
+                return "%s%s" % (pre_word, wrd)
 
             if self.total_digits_outside_triplets == 1:
                 if self.order_of_last_zero_digit == 0:
@@ -156,7 +162,7 @@ class Num2Word_TR(Num2Word_Base):
                     )
                     if self.integers_to_read[0][0] == "0":
                         return self.ZERO
-                    return wrd
+                    return "%s%s" % (pre_word, wrd)
 
             if self.total_digits_outside_triplets == 0:
                 if self.order_of_last_zero_digit == 2:
@@ -165,7 +171,7 @@ class Num2Word_TR(Num2Word_Base):
                         self.integers_to_read[0][0], ""
                     )
                     wrd += self.CARDINAL_HUNDRED[0]
-                    return wrd
+                    return "%s%s" % (pre_word, wrd)
                 if self.order_of_last_zero_digit == 1:
                     # number like xy0, read cardinal xy0 and return
                     wrd += self.HUNDREDS.get(
@@ -175,7 +181,7 @@ class Num2Word_TR(Num2Word_Base):
                     wrd += self.CARDINAL_TENS.get(
                         self.integers_to_read[0][1], ""
                     )
-                    return wrd
+                    return "%s%s" % (pre_word, wrd)
                 if self.order_of_last_zero_digit == 0:
                     # number like xyz, read cardinal xyz and return
                     wrd += self.HUNDREDS.get(
@@ -188,7 +194,7 @@ class Num2Word_TR(Num2Word_Base):
                     wrd += self.CARDINAL_ONES.get(
                         self.integers_to_read[0][2], ""
                     )
-                    return wrd
+                    return "%s%s" % (pre_word, wrd)
 
         if self.total_triplets_to_read >= 2:
             if self.total_digits_outside_triplets == 2:
@@ -202,7 +208,7 @@ class Num2Word_TR(Num2Word_Base):
                     wrd += self.CARDINAL_TRIPLETS[
                         self.total_triplets_to_read - 1
                     ]
-                    return wrd
+                    return "%s%s" % (pre_word, wrd)
                 if self.order_of_last_zero_digit == len(
                         self.integers_to_read[0]) - 2:
                     # number like xy and all 0s, read cardinal xy 0..0
@@ -216,7 +222,7 @@ class Num2Word_TR(Num2Word_Base):
                     wrd += self.CARDINAL_TRIPLETS[
                         self.total_triplets_to_read - 1
                     ]
-                    return wrd
+                    return "%s%s" % (pre_word, wrd)
                 if self.order_of_last_zero_digit < len(
                         self.integers_to_read[0]) - 2:
                     # number like xy and others, read cardinal xy n..n
@@ -244,7 +250,7 @@ class Num2Word_TR(Num2Word_Base):
                     wrd += self.CARDINAL_TRIPLETS[
                         self.total_triplets_to_read - 1
                     ]
-                    return wrd
+                    return "%s%s" % (pre_word, wrd)
                 if self.order_of_last_zero_digit < len(
                         self.integers_to_read[0]) - 1:
                     # number like x and others, read cardinal x n..n
@@ -268,7 +274,7 @@ class Num2Word_TR(Num2Word_Base):
                     wrd += self.CARDINAL_TRIPLETS[
                         self.total_triplets_to_read - 1
                     ]
-                    return wrd
+                    return "%s%s" % (pre_word, wrd)
                 if self.order_of_last_zero_digit == len(
                         self.integers_to_read[0]) - 2:
                     # number like xy0 and all 0s, read cardinal xy0 0..0
@@ -283,7 +289,7 @@ class Num2Word_TR(Num2Word_Base):
                     wrd += self.CARDINAL_TRIPLETS[
                         self.total_triplets_to_read - 1
                     ]
-                    return wrd
+                    return "%s%s" % (pre_word, wrd)
                 if self.order_of_last_zero_digit == len(
                         self.integers_to_read[0]) - 3:
                     # number like xyz and all 0s, read cardinal xyz 0..0
@@ -299,7 +305,7 @@ class Num2Word_TR(Num2Word_Base):
                     wrd += self.CARDINAL_TRIPLETS[
                         self.total_triplets_to_read - 1
                     ]
-                    return wrd
+                    return "%s%s" % (pre_word, wrd)
                 if self.order_of_last_zero_digit < len(
                         self.integers_to_read[0]) - 3:
                     # number like xyz and all others, read cardinal xyz n..n
@@ -339,11 +345,11 @@ class Num2Word_TR(Num2Word_Base):
                                 last_read_digit_order) - 1:
                             if i == 1:
                                 wrd += self.CARDINAL_HUNDRED[0]
-                                return wrd
+                                return "%s%s" % (pre_word, wrd)
                             elif i > 1:
                                 wrd += self.CARDINAL_HUNDRED[0]
                                 wrd += self.CARDINAL_TRIPLETS[i - 1]
-                                return wrd
+                                return "%s%s" % (pre_word, wrd)
                         else:
                             wrd += self.CARDINAL_HUNDRED[0]
 
@@ -357,14 +363,14 @@ class Num2Word_TR(Num2Word_Base):
                                     self.integers_to_read[0][
                                         last_read_digit_order + 1], ""
                                 )
-                                return wrd
+                                return "%s%s" % (pre_word, wrd)
                             elif i > 1:
                                 wrd += self.CARDINAL_TENS.get(
                                     self.integers_to_read[0][
                                         last_read_digit_order + 1], ""
                                 )
                                 wrd += self.CARDINAL_TRIPLETS[i - 1]
-                                return wrd
+                                return "%s%s" % (pre_word, wrd)
                         else:
                             wrd += self.CARDINAL_TENS.get(
                                 self.integers_to_read[0][
@@ -381,7 +387,7 @@ class Num2Word_TR(Num2Word_Base):
                                     self.integers_to_read[0][
                                         last_read_digit_order + 2], ""
                                 )
-                                return wrd
+                                return "%s%s" % (pre_word, wrd)
                             if i == 2:
                                 if not self.integers_to_read[0][
                                         last_read_digit_order:
@@ -398,14 +404,14 @@ class Num2Word_TR(Num2Word_Base):
                                             last_read_digit_order + 2], ""
                                     )
                                 wrd += self.CARDINAL_TRIPLETS[i - 1]
-                                return wrd
+                                return "%s%s" % (pre_word, wrd)
                             if i > 2:
                                 wrd += self.CARDINAL_ONES.get(
                                     self.integers_to_read[0][
                                         last_read_digit_order + 2], ""
                                 )
                                 wrd += self.CARDINAL_TRIPLETS[i - 1]
-                                return wrd
+                                return "%s%s" % (pre_word, wrd)
                         else:
                             if not self.integers_to_read[0][
                                     last_read_digit_order:
@@ -435,7 +441,7 @@ class Num2Word_TR(Num2Word_Base):
 
                     wrd += self.CARDINAL_TRIPLETS[i - 1]
 
-        return wrd
+        return "%s%s" % (pre_word, wrd)
 
     def to_cardinal_float(self, value):
         self.to_splitnum(value)

--- a/tests/test_tr.py
+++ b/tests/test_tr.py
@@ -186,7 +186,11 @@ class Num2WordsTRTest(TestCase):
             {"test": 10, "to": "ordinal_num", "expected": u"10uncu"},
             {"test": 1, "to": "ordinal_num", "expected": u"1inci"},
             {"test": 3, "to": "ordinal_num", "expected": u"3üncü"},
-            {"test": 6, "to": "ordinal_num", "expected": u"6ıncı"}
+            {"test": 6, "to": "ordinal_num", "expected": u"6ıncı"},
+            {"test": -5, "to": "cardinal", "expected": u"eksibeş"},
+            {"test": -55, "to": "cardinal", "expected": u"eksiellibeş"},
+            {"test": -576, "to": "cardinal", "expected": u"eksibeşyüzyetmişaltı"},
+            {"test": -3, "to": "currency", "expected": u"eksiüçlira"},
         ]
 
         for casedata in testcases:

--- a/tests/test_tr.py
+++ b/tests/test_tr.py
@@ -190,7 +190,7 @@ class Num2WordsTRTest(TestCase):
             {"test": -5, "to": "cardinal", "expected": u"eksibeş"},
             {"test": -55, "to": "cardinal", "expected": u"eksiellibeş"},
             {"test": -576, "to": "cardinal",
-            "expected": u"eksibeşyüzyetmişaltı"},
+             "expected": u"eksibeşyüzyetmişaltı"},
             {"test": -3, "to": "currency", "expected": u"eksiüçlira"},
         ]
 

--- a/tests/test_tr.py
+++ b/tests/test_tr.py
@@ -189,7 +189,8 @@ class Num2WordsTRTest(TestCase):
             {"test": 6, "to": "ordinal_num", "expected": u"6ıncı"},
             {"test": -5, "to": "cardinal", "expected": u"eksibeş"},
             {"test": -55, "to": "cardinal", "expected": u"eksiellibeş"},
-            {"test": -576, "to": "cardinal", "expected": u"eksibeşyüzyetmişaltı"},
+            {"test": -576, "to": "cardinal",
+            "expected": u"eksibeşyüzyetmişaltı"},
             {"test": -3, "to": "currency", "expected": u"eksiüçlira"},
         ]
 


### PR DESCRIPTION
#454 Negative Number return wrong text Fixes @emregeldegul

### Changes proposed in this pull request:

* -50 (cardinal) -> eksielli
* -3 (currency) -> eksiellilira

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Add new cases in the turkish test for negative numbers

### Additional notes

I opened a [PR](https://github.com/savoirfairelinux/num2words/pull/455) before but closed it because there were too many conflicts. 
