### PR TITLE
correct the fr_DZ currency unit

### DIFF
--- a/num2words/lang_FR_DZ.py
+++ b/num2words/lang_FR_DZ.py
@@ -22,7 +22,7 @@ from .lang_FR import Num2Word_FR
 
 class Num2Word_FR_DZ(Num2Word_FR):
     CURRENCY_FORMS = {
-        'DIN': (('Dinar', 'Dinars'), ('centime', 'centimes')),
+        'DIN': (('Dinar', 'Dinars'), ('Centime', 'Centimes')),
     }
 
     def to_currency(self, val, currency='DIN', cents=True, separator=' et',

--- a/num2words/lang_FR_DZ.py
+++ b/num2words/lang_FR_DZ.py
@@ -22,7 +22,7 @@ from .lang_FR import Num2Word_FR
 
 class Num2Word_FR_DZ(Num2Word_FR):
     CURRENCY_FORMS = {
-        'DIN': (('dinard', 'dinards'), ('centime', 'centimes')),
+        'DIN': (('Dinar', 'Dinars'), ('centime', 'centimes')),
     }
 
     def to_currency(self, val, currency='DIN', cents=True, separator=' et',


### PR DESCRIPTION
## Fixes # by fiberstudio

### Changes proposed in this pull request:

* correct the fr_DZ currency unit, from 'dinard' to dinar
* Initial capitalized to highlight the unit

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

*i work in ALgeria, and as far as i know, 'dinard' is 100% a mistake, the currency unit is just like that of France, which is 'dinar'*


### Additional notes

*If applicable, explain the rationale behind your change.*

thanks for your contributuion, num2words really helps me in my work. And i just want corret the little mistake in it to make num2words a more robust module. Thanks for your preview.

