### PR TITLE
Norwegian uplift

### DIFF
--- a/num2words/lang_NO.py
+++ b/num2words/lang_NO.py
@@ -50,8 +50,7 @@ class Num2Word_NO(lang_EU.Num2Word_EU):
                              "tolv", "elleve", "ti", "ni", "\xe5tte",
                              "syv", "seks", "fem", "fire", "tre", "to",
                              "en", "null"]
-        self.ords = {"en": "f\xf8rste",
-                     "to": "andre",
+        self.ords_pl = {"to": "andre",
                      "tre": "tredje",
                      "fire": "fjerde",
                      "fem": "femte",
@@ -62,7 +61,15 @@ class Num2Word_NO(lang_EU.Num2Word_EU):
                      "ti": "tiende",
                      "elleve": "ellevte",
                      "tolv": "tolvte",
+                     "fjorten": "fjortende",
+                     "femten": "femtende",
+                     "seksten": "sekstende",
+                     "sytten": "syttende",
+                     "atten": "attende",
+                     "nitten": "nittende",
                      "tjue": "tjuende"}
+        # this needs to be done separately to not block 13-19 to_ordinal (as they all end with "-en")
+        self.ords_sg = {"en": "f\xf8rste"}
 
     def merge(self, lpair, rpair):
         ltext, lnum = lpair
@@ -70,7 +77,7 @@ class Num2Word_NO(lang_EU.Num2Word_EU):
         if lnum == 1 and rnum < 100:
             return (rtext, rnum)
         elif 100 > lnum > rnum:
-            return ("%s-%s" % (ltext, rtext), lnum + rnum)
+            return ("%s%s" % (ltext, rtext), lnum + rnum)
         elif lnum >= 100 > rnum:
             return ("%s og %s" % (ltext, rtext), lnum + rnum)
         elif rnum > lnum:
@@ -79,19 +86,16 @@ class Num2Word_NO(lang_EU.Num2Word_EU):
 
     def to_ordinal(self, value):
         self.verify_ordinal(value)
-        outwords = self.to_cardinal(value).split(" ")
-        lastwords = outwords[-1].split("-")
-        lastword = lastwords[-1].lower()
-        try:
-            lastword = self.ords[lastword]
-        except KeyError:
-            if lastword[-2:] == "ti":
-                lastword = lastword + "ende"
-            else:
-                lastword += "de"
-        lastwords[-1] = self.title(lastword)
-        outwords[-1] = "".join(lastwords)
-        return " ".join(outwords)
+        outword = self.to_cardinal(value)
+        for key in self.ords_pl:
+            if outword.endswith(key):
+                outword = outword[:len(outword) - len(key)] + self.ords_pl[key]
+                break
+        for key in self.ords_sg:
+            if outword.endswith(key):
+                outword = outword[:len(outword) - len(key)] + self.ords_sg[key]
+                break
+        return outword
 
     def to_ordinal_num(self, value):
         self.verify_ordinal(value)

--- a/num2words/lang_NO.py
+++ b/num2words/lang_NO.py
@@ -68,7 +68,10 @@ class Num2Word_NO(lang_EU.Num2Word_EU):
                         "sytten": "syttende",
                         "atten": "attende",
                         "nitten": "nittende",
-                        "tjue": "tjuende"}
+                        "tjue": "tjuende",
+                        "hundre": "hundrede",
+                        "tusen": "tusende",
+                        "million": "millionte"}
         # this needs to be done separately to not block 13-19 to_ordinal
         self.ords_sg = {"en": "f\xf8rste"}
 

--- a/num2words/lang_NO.py
+++ b/num2words/lang_NO.py
@@ -83,7 +83,7 @@ class Num2Word_NO(lang_EU.Num2Word_EU):
             return ("%s og %s" % (ltext, rtext), lnum + rnum)
         elif rnum > lnum:
             return ("%s %s" % (ltext, rtext), lnum * rnum)
-        return ("%s, %s" % (ltext, rtext), lnum + rnum)
+        return ("%s %s" % (ltext, rtext), lnum + rnum)
 
     def to_ordinal(self, value):
         self.verify_ordinal(value)

--- a/num2words/lang_NO.py
+++ b/num2words/lang_NO.py
@@ -99,7 +99,7 @@ class Num2Word_NO(lang_EU.Num2Word_EU):
 
     def to_ordinal_num(self, value):
         self.verify_ordinal(value)
-        return "%s%s" % (value, self.to_ordinal(value)[-2:])
+        return str(value) + "."
 
     def to_year(self, val, longval=True):
         if not (val // 100) % 10:

--- a/num2words/lang_NO.py
+++ b/num2words/lang_NO.py
@@ -52,24 +52,24 @@ class Num2Word_NO(lang_EU.Num2Word_EU):
                              "syv", "seks", "fem", "fire", "tre", "to",
                              "en", "null"]
         self.ords_pl = {"to": "andre",
-                     "tre": "tredje",
-                     "fire": "fjerde",
-                     "fem": "femte",
-                     "seks": "sjette",
-                     "syv": "syvende",
-                     "\xe5tte": "\xe5ttende",
-                     "ni": "niende",
-                     "ti": "tiende",
-                     "elleve": "ellevte",
-                     "tolv": "tolvte",
-                     "fjorten": "fjortende",
-                     "femten": "femtende",
-                     "seksten": "sekstende",
-                     "sytten": "syttende",
-                     "atten": "attende",
-                     "nitten": "nittende",
-                     "tjue": "tjuende"}
-        # this needs to be done separately to not block 13-19 to_ordinal (as they all end with "-en")
+                        "tre": "tredje",
+                        "fire": "fjerde",
+                        "fem": "femte",
+                        "seks": "sjette",
+                        "syv": "syvende",
+                        "\xe5tte": "\xe5ttende",
+                        "ni": "niende",
+                        "ti": "tiende",
+                        "elleve": "ellevte",
+                        "tolv": "tolvte",
+                        "fjorten": "fjortende",
+                        "femten": "femtende",
+                        "seksten": "sekstende",
+                        "sytten": "syttende",
+                        "atten": "attende",
+                        "nitten": "nittende",
+                        "tjue": "tjuende"}
+        # this needs to be done separately to not block 13-19 to_ordinal
         self.ords_sg = {"en": "f\xf8rste"}
 
     def merge(self, lpair, rpair):
@@ -113,7 +113,7 @@ class Num2Word_NO(lang_EU.Num2Word_EU):
         result = super(Num2Word_NO, self).to_currency(
             val, currency=currency, cents=cents, separator=separator,
             adjective=adjective)
-        
-         # do not print "og null øre"
+
+        # do not print "og null øre"
         result = result.replace(' og null øre', '')
         return result

--- a/num2words/lang_NO.py
+++ b/num2words/lang_NO.py
@@ -23,6 +23,7 @@ from . import lang_EU
 class Num2Word_NO(lang_EU.Num2Word_EU):
     GIGA_SUFFIX = "illard"
     MEGA_SUFFIX = "illion"
+    CURRENCY_FORMS = {'NOK': (('krone', 'kroner'), ('øre', 'øre'))}
 
     def set_high_numwords(self, high):
         cap = 3 + 6 * len(high)
@@ -107,6 +108,12 @@ class Num2Word_NO(lang_EU.Num2Word_EU):
         return self.to_splitnum(val, hightxt="hundre", jointxt="og",
                                 longval=longval)
 
-    def to_currency(self, val, longval=True):
-        return self.to_splitnum(val, hightxt="krone/r", lowtxt="\xf8re/r",
-                                jointxt="og", longval=longval, cents=True)
+    def to_currency(self, val, currency='NOK', cents=True, separator=' og',
+                    adjective=False):
+        result = super(Num2Word_NO, self).to_currency(
+            val, currency=currency, cents=cents, separator=separator,
+            adjective=adjective)
+        
+         # do not print "og null øre"
+        result = result.replace(' og null øre', '')
+        return result

--- a/tests/test_no.py
+++ b/tests/test_no.py
@@ -51,8 +51,10 @@ class Num2WordsNOTest(TestCase):
         self.assertEqual(num2words(14, to="ordinal", lang="no"), "fjortende")
         self.assertEqual(num2words(30, to="ordinal", lang="no"), "trettiende")
         self.assertEqual(num2words(32, to="ordinal", lang="no"), "trettiandre")
-        self.assertEqual(num2words(100, to="ordinal", lang="no"), "en hundrede")
-        self.assertEqual(num2words(1000, to="ordinal", lang="no"), "en tusende")
+        self.assertEqual(num2words(100, to="ordinal", lang="no"),
+                         "en hundrede")
+        self.assertEqual(num2words(1000, to="ordinal", lang="no"),
+                         "en tusende")
         self.assertEqual(num2words(1435, to="ordinal", lang="no"),
                          "en tusen fire hundre og trettifemte")
         self.assertEqual(num2words(1000000, to="ordinal", lang="no"),

--- a/tests/test_no.py
+++ b/tests/test_no.py
@@ -1,0 +1,73 @@
+# coding: utf-8
+# Copyright (c) 2003, Taro Ogawa.  All Rights Reserved.
+# Copyright (c) 2013, Savoir-faire Linux inc.  All Rights Reserved.
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301 USA
+
+from __future__ import unicode_literals
+
+from unittest import TestCase
+
+from num2words import num2words
+
+
+class Num2WordsNOTest(TestCase):
+    def test_cardinal(self):
+        self.assertEqual(num2words(0, to="cardinal", lang="no"), "null")
+        self.assertEqual(num2words(1, to="cardinal", lang="no"), "en")
+        self.assertEqual(num2words(3, to="cardinal", lang="no"), "tre")
+        self.assertEqual(num2words(5, to="cardinal", lang="no"), "fem")
+        self.assertEqual(num2words(18, to="cardinal", lang="no"), "atten")
+        self.assertEqual(num2words(45, to="cardinal", lang="no"), "førtifem")
+        self.assertEqual(num2words(92, to="cardinal", lang="no"), "nittito")
+        self.assertEqual(num2words(1345, to="cardinal", lang="no"),
+                         "en tusen tre hundre og førtifem")
+        self.assertEqual(num2words(4435, to="cardinal", lang="no"),
+                         "fire tusen fire hundre og trettifem")
+        self.assertEqual(num2words(1004435, to="cardinal", lang="no"),
+                         "en million fire tusen fire hundre og trettifem")
+        self.assertEqual(num2words(4335000, to="cardinal", lang="no"),
+                         "fire million tre hundre og trettifem tusen")
+        self.assertEqual(num2words(14004535, to="cardinal", lang="no"),
+                         "fjorten million fire tusen fem hundre og trettifem")
+        self.assertEqual(num2words(1.5, to="cardinal", lang="no"), "en komma fem")
+    
+    def test_ordinal(self):
+        self.assertEqual(num2words(1, to="ordinal", lang="no"), "første")
+        self.assertEqual(num2words(5, to="ordinal", lang="no"), "femte")
+        self.assertEqual(num2words(10, to="ordinal", lang="no"), "tiende")
+        self.assertEqual(num2words(14, to="ordinal", lang="no"), "fjortende")
+        self.assertEqual(num2words(30, to="ordinal", lang="no"),"trettiende")
+        self.assertEqual(num2words(32, to="ordinal", lang="no"),"trettiandre")
+        self.assertEqual(num2words(1435, to="ordinal", lang="no"),
+                         "en tusen fire hundre og trettifemte")
+    
+    def test_ordinal_num(self):
+        self.assertEqual(num2words(1, to="ordinal_num", lang="no"), "1.")
+        self.assertEqual(num2words(5, to="ordinal_num", lang="no"), "5.")
+        self.assertEqual(num2words(10, to="ordinal_num", lang="no"), "10.")
+        self.assertEqual(num2words(14, to="ordinal_num", lang="no"), "14.")
+        self.assertEqual(num2words(32, to="ordinal_num", lang="no"), "32.")
+
+    def test_year(self):
+        self.assertEqual(num2words(1835, to="year", lang="no"), "atten hundre og trettifem")
+        self.assertEqual(num2words(2015, to="year", lang="no"), "to tusen og femten")
+    
+    def test_currency(self):
+        self.assertEqual(num2words(1.00, to="currency", lang="no"), "en krone")
+        self.assertEqual(num2words(2.00, to="currency", lang="no"), "to kroner")
+        self.assertEqual(num2words(2.50, to="currency", lang="no"), "to kroner og femti øre")
+        self.assertEqual(num2words(135.00, to="currency", lang="no"), "en hundre og trettifem kroner")
+        self.assertEqual(num2words(135.59, to="currency", lang="no"), "en hundre og trettifem kroner og femtini øre")
+    

--- a/tests/test_no.py
+++ b/tests/test_no.py
@@ -41,18 +41,19 @@ class Num2WordsNOTest(TestCase):
                          "fire million tre hundre og trettifem tusen")
         self.assertEqual(num2words(14004535, to="cardinal", lang="no"),
                          "fjorten million fire tusen fem hundre og trettifem")
-        self.assertEqual(num2words(1.5, to="cardinal", lang="no"), "en komma fem")
-    
+        self.assertEqual(num2words(1.5, to="cardinal", lang="no"),
+                         "en komma fem")
+
     def test_ordinal(self):
         self.assertEqual(num2words(1, to="ordinal", lang="no"), "første")
         self.assertEqual(num2words(5, to="ordinal", lang="no"), "femte")
         self.assertEqual(num2words(10, to="ordinal", lang="no"), "tiende")
         self.assertEqual(num2words(14, to="ordinal", lang="no"), "fjortende")
-        self.assertEqual(num2words(30, to="ordinal", lang="no"),"trettiende")
-        self.assertEqual(num2words(32, to="ordinal", lang="no"),"trettiandre")
+        self.assertEqual(num2words(30, to="ordinal", lang="no"), "trettiende")
+        self.assertEqual(num2words(32, to="ordinal", lang="no"), "trettiandre")
         self.assertEqual(num2words(1435, to="ordinal", lang="no"),
                          "en tusen fire hundre og trettifemte")
-    
+
     def test_ordinal_num(self):
         self.assertEqual(num2words(1, to="ordinal_num", lang="no"), "1.")
         self.assertEqual(num2words(5, to="ordinal_num", lang="no"), "5.")
@@ -61,13 +62,18 @@ class Num2WordsNOTest(TestCase):
         self.assertEqual(num2words(32, to="ordinal_num", lang="no"), "32.")
 
     def test_year(self):
-        self.assertEqual(num2words(1835, to="year", lang="no"), "atten hundre og trettifem")
-        self.assertEqual(num2words(2015, to="year", lang="no"), "to tusen og femten")
-    
+        self.assertEqual(num2words(1835, to="year", lang="no"),
+                         "atten hundre og trettifem")
+        self.assertEqual(num2words(2015, to="year", lang="no"),
+                         "to tusen og femten")
+
     def test_currency(self):
         self.assertEqual(num2words(1.00, to="currency", lang="no"), "en krone")
-        self.assertEqual(num2words(2.00, to="currency", lang="no"), "to kroner")
-        self.assertEqual(num2words(2.50, to="currency", lang="no"), "to kroner og femti øre")
-        self.assertEqual(num2words(135.00, to="currency", lang="no"), "en hundre og trettifem kroner")
-        self.assertEqual(num2words(135.59, to="currency", lang="no"), "en hundre og trettifem kroner og femtini øre")
-    
+        self.assertEqual(num2words(2.00, to="currency", lang="no"),
+                         "to kroner")
+        self.assertEqual(num2words(2.50, to="currency", lang="no"),
+                         "to kroner og femti øre")
+        self.assertEqual(num2words(135.00, to="currency", lang="no"),
+                         "en hundre og trettifem kroner")
+        self.assertEqual(num2words(135.59, to="currency", lang="no"),
+                         "en hundre og trettifem kroner og femtini øre")

--- a/tests/test_no.py
+++ b/tests/test_no.py
@@ -51,8 +51,12 @@ class Num2WordsNOTest(TestCase):
         self.assertEqual(num2words(14, to="ordinal", lang="no"), "fjortende")
         self.assertEqual(num2words(30, to="ordinal", lang="no"), "trettiende")
         self.assertEqual(num2words(32, to="ordinal", lang="no"), "trettiandre")
+        self.assertEqual(num2words(100, to="ordinal", lang="no"), "en hundrede")
+        self.assertEqual(num2words(1000, to="ordinal", lang="no"), "en tusende")
         self.assertEqual(num2words(1435, to="ordinal", lang="no"),
                          "en tusen fire hundre og trettifemte")
+        self.assertEqual(num2words(1000000, to="ordinal", lang="no"),
+                         "en millionte")
 
     def test_ordinal_num(self):
         self.assertEqual(num2words(1, to="ordinal_num", lang="no"), "1.")


### PR DESCRIPTION
## Norwegian Uplift by gealodge

This may fix #110 but was not the motivation for the fix

### Changes proposed in this pull request:

* 'lang_NO.py':
    * Removed hyphen between tens and units (e.g. `92` should convert to `nittito` not `nitti-to`)
    * Fixed currency conversion (this was v broken)
    * Corrected ordinal_num (looks like this had not been changed from copying English)
    * removed comma from long word form numbers

* 'test_no.py':
    * Created Norwegian test cases file with test cases

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

I have added hopefully quite comprehensive tests for the changes I have made and generally basic tests for Norwegian. Specific examples include:

```>>> from num2words import num2words
>>> num2words('92', lang='no')
'nittito'
>>> num2words('1345', lang='no')
'en tusen tre hundre og førtifem'
>>> num2words('5', lang='no', to='ordinal')
'femte'
>>> num2words('5', lang='no', to='ordinal_num')
'5.'
>>> num2words('12', lang='no', to='currency')
'tolv kroner'
```

### Additional notes

There were no tests, these needed adding. The currency conversion was completely broken, essentially dividing the numbers by 100 before converting. Hyphens and commas don't belong in Norwegian numbers like that, so I've removed them. I had to do a big shift around for the ordinals to get that working.

