### PR TITLE
40 is "fyrtio" in Swedish

### DIFF
--- a/num2words/lang_SV.py
+++ b/num2words/lang_SV.py
@@ -43,7 +43,7 @@ class Num2Word_SV(lang_EU.Num2Word_EU):
 
         self.mid_numwords = [(1000, "tusen"), (100, "hundra"),
                              (90, "nittio"), (80, "åttio"), (70, "sjuttio"),
-                             (60, "sextio"), (50, "femtio"), (40, "förtio"),
+                             (60, "sextio"), (50, "femtio"), (40, "fyrtio"),
                              (30, "trettio")]
         self.low_numwords = ["tjugo", "nitton", "arton", "sjutton",
                              "sexton", "femton", "fjorton", "tretton",


### PR DESCRIPTION
In Swedish, "förtio" is an informal non-standard spelling of 40.  "Fyrtio" is the formal and established spelling of 40 in Swedish.

### Changes proposed in this pull request:

* Change the spelling of 40 in Swedish to an established spelling (fyrtio) instead of the current spelling (förtio) which is a heavily informal and less used spelling. 

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change
[English wiktionary entry: fyrtio](https://en.wiktionary.org/wiki/fyrtio)
[Swedish wiktionary entry: fyrtio](https://sv.wiktionary.org/wiki/fyrtio) (mentions "förtio" as a variant that is heavily informal).
