### PR TITLE
Change python3.6 to python3.11 because deprecation in ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -27,11 +27,11 @@ CLASSIFIERS = [
     'Intended Audience :: Developers',
     'License :: OSI Approved :: GNU Library or Lesser General Public License '
     '(LGPL)',
-    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Topic :: Software Development :: Internationalization',
     'Topic :: Software Development :: Libraries :: Python Modules',
     'Topic :: Software Development :: Localization',

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
-envlist = py36,py37,py38,py39,py310,flake8,isort
+envlist = py37,py38,py39,py310,py311,flake8,isort
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
 	3.9: py39
 	3.10: isort, flake8, py310
+    3.11: py311
 
 
 [testenv]
@@ -23,7 +23,7 @@ commands =
 [testenv:flake8]
 changedir = {toxinidir}
 deps =
-    flake8
+    flake8==5.0.4
     flake8-copyright
 commands =
     flake8


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:


 *  Removed python3.6 from testing because is deprecated in ubuntu 20.04
 *  Added python 3.11
 *  Set flake to fix version 5


### Status

- [x ] READY
- [ ] HOLD
- [] WIP (Work-In-Progress)

### How to verify this change

*Fill out this section so that a reviewer can know how to verify your change.*

### Additional notes

*If applicable, explain the rationale behind your change.*

