### PR TITLE
Added support for the Nigerian Naira

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ In code there's only one function to use::
     >>> num2words(42, lang='fr')
     quarante-deux
 
-Besides the numerical argument, there are two main optional arguments.
+Besides the numerical argument, there are two main optional arguments, ``to:`` and ``lang:``
 
 **to:** The converter to use. Supported values are:
 
@@ -84,6 +84,7 @@ Besides the numerical argument, there are two main optional arguments.
 * ``dk`` (Danish)
 * ``en_GB`` (English - Great Britain)
 * ``en_IN`` (English - India)
+* ``en_NG`` (English - Nigeria)
 * ``es`` (Spanish)
 * ``es_CO`` (Spanish - Colombia)
 * ``es_VE`` (Spanish - Venezuela)

--- a/num2words/__init__.py
+++ b/num2words/__init__.py
@@ -18,13 +18,13 @@
 from __future__ import unicode_literals
 
 from . import (lang_AM, lang_AR, lang_AZ, lang_CZ, lang_DE, lang_DK, lang_EN,
-               lang_EN_IN, lang_EO, lang_ES, lang_ES_CO, lang_ES_NI,
-               lang_ES_VE, lang_FA, lang_FI, lang_FR, lang_FR_BE, lang_FR_CH,
-               lang_FR_DZ, lang_HE, lang_HU, lang_ID, lang_IS, lang_IT,
-               lang_JA, lang_KN, lang_KO, lang_KZ, lang_LT, lang_LV, lang_NL,
-               lang_NO, lang_PL, lang_PT, lang_PT_BR, lang_RO, lang_RU,
-               lang_SL, lang_SR, lang_SV, lang_TE, lang_TG, lang_TH, lang_TR,
-               lang_UK, lang_VI, lang_EN_NG)
+               lang_EN_IN, lang_EN_NG, lang_EO, lang_ES, lang_ES_CO,
+               lang_ES_NI, lang_ES_VE, lang_FA, lang_FI, lang_FR,
+               lang_FR_BE, lang_FR_CH, lang_FR_DZ, lang_HE, lang_HU,
+               lang_ID, lang_IS, lang_IT, lang_JA, lang_KN, lang_KO,
+               lang_KZ, lang_LT, lang_LV, lang_NL, lang_NO, lang_PL,
+               lang_PT, lang_PT_BR, lang_RO, lang_RU, lang_SL, lang_SR,
+               lang_SV, lang_TE, lang_TG, lang_TH, lang_TR, lang_UK, lang_VI)
 
 CONVERTER_CLASSES = {
     'am': lang_AM.Num2Word_AM(),

--- a/num2words/__init__.py
+++ b/num2words/__init__.py
@@ -19,12 +19,12 @@ from __future__ import unicode_literals
 
 from . import (lang_AM, lang_AR, lang_AZ, lang_CZ, lang_DE, lang_DK, lang_EN,
                lang_EN_IN, lang_EN_NG, lang_EO, lang_ES, lang_ES_CO,
-               lang_ES_NI, lang_ES_VE, lang_FA, lang_FI, lang_FR,
-               lang_FR_BE, lang_FR_CH, lang_FR_DZ, lang_HE, lang_HU,
-               lang_ID, lang_IS, lang_IT, lang_JA, lang_KN, lang_KO,
-               lang_KZ, lang_LT, lang_LV, lang_NL, lang_NO, lang_PL,
-               lang_PT, lang_PT_BR, lang_RO, lang_RU, lang_SL, lang_SR,
-               lang_SV, lang_TE, lang_TG, lang_TH, lang_TR, lang_UK, lang_VI)
+               lang_ES_NI, lang_ES_VE, lang_FA, lang_FI, lang_FR, lang_FR_BE,
+               lang_FR_CH, lang_FR_DZ, lang_HE, lang_HU, lang_ID, lang_IS,
+               lang_IT, lang_JA, lang_KN, lang_KO, lang_KZ, lang_LT, lang_LV,
+               lang_NL, lang_NO, lang_PL, lang_PT, lang_PT_BR, lang_RO,
+               lang_RU, lang_SL, lang_SR, lang_SV, lang_TE, lang_TG, lang_TH,
+               lang_TR, lang_UK, lang_VI)
 
 CONVERTER_CLASSES = {
     'am': lang_AM.Num2Word_AM(),

--- a/num2words/__init__.py
+++ b/num2words/__init__.py
@@ -24,7 +24,7 @@ from . import (lang_AM, lang_AR, lang_AZ, lang_CZ, lang_DE, lang_DK, lang_EN,
                lang_JA, lang_KN, lang_KO, lang_KZ, lang_LT, lang_LV, lang_NL,
                lang_NO, lang_PL, lang_PT, lang_PT_BR, lang_RO, lang_RU,
                lang_SL, lang_SR, lang_SV, lang_TE, lang_TG, lang_TH, lang_TR,
-               lang_UK, lang_VI)
+               lang_UK, lang_VI, lang_EN_NG)
 
 CONVERTER_CLASSES = {
     'am': lang_AM.Num2Word_AM(),
@@ -33,6 +33,7 @@ CONVERTER_CLASSES = {
     'cz': lang_CZ.Num2Word_CZ(),
     'en': lang_EN.Num2Word_EN(),
     'en_IN': lang_EN_IN.Num2Word_EN_IN(),
+    'en_NG': lang_EN_NG.Num2Word_EN_NG(),
     'fa': lang_FA.Num2Word_FA(),
     'fr': lang_FR.Num2Word_FR(),
     'fr_CH': lang_FR_CH.Num2Word_FR_CH(),

--- a/num2words/lang_EN_NG.py
+++ b/num2words/lang_EN_NG.py
@@ -19,6 +19,7 @@ from __future__ import unicode_literals
 
 from . import lang_EN
 
+
 class Num2Word_EN_NG(lang_EN.Num2Word_EN):
 
     CURRENCY_FORMS = {'NGN': (('naira', 'naira'), ('kobo', 'kobo'))}
@@ -26,7 +27,7 @@ class Num2Word_EN_NG(lang_EN.Num2Word_EN):
     CURRENCY_ADJECTIVES = {'NGN': 'Nigerian'}
 
     def to_currency(
-        self, val, currency='NGN', 
+        self, val, currency='NGN',
         kobo=True, separator=',',
         adjective=False
     ):

--- a/num2words/lang_EN_NG.py
+++ b/num2words/lang_EN_NG.py
@@ -27,10 +27,10 @@ class Num2Word_EN_NG(lang_EN.Num2Word_EN):
 
     def to_currency(
         self, val, currency='NGN', 
-        cents=True, separator=',',
+        kobo=True, separator=',',
         adjective=False
     ):
         result = super(Num2Word_EN_NG, self).to_currency(
-            val, currency=currency, cents=cents, separator=separator,
+            val, currency=currency, cents=kobo, separator=separator,
             adjective=adjective)
         return result

--- a/num2words/lang_EN_NG.py
+++ b/num2words/lang_EN_NG.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2003, Taro Ogawa.  All Rights Reserved.
+# Copyright (c) 2013, Savoir-faire Linux inc.  All Rights Reserved.
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301 USA
+
+from __future__ import unicode_literals
+
+from . import lang_EN
+
+class Num2Word_EN_NG(lang_EN.Num2Word_EN):
+
+    CURRENCY_FORMS = {'NGN': (('naira', 'naira'), ('kobo', 'kobo'))}
+
+    CURRENCY_ADJECTIVES = {'NGN': 'Nigerian'}
+
+    def to_currency(
+        self, val, currency='NGN', 
+        cents=True, separator=',',
+        adjective=False
+    ):
+        result = super(Num2Word_EN_NG, self).to_currency(
+            val, currency=currency, cents=cents, separator=separator,
+            adjective=adjective)
+        return result

--- a/tests/test_en_ng.py
+++ b/tests/test_en_ng.py
@@ -22,8 +22,10 @@ from num2words import num2words
 
 class Num2WordsENNGTest(TestCase):
 
-    # only the test for currency is writen as other functions in the Class remains the 
-    # same and have been properly tested in the test test_en which tests the parent class
+    # only the test for currency is writen as other
+    # functions in the Class remains the
+    # same and have been properly tested in the
+    # test test_en which tests the parent class
     # upon which this class inherits
 
     def test_to_currency(self):
@@ -32,60 +34,110 @@ class Num2WordsENNGTest(TestCase):
         separator = ' and'
 
         self.assertEqual(
-            num2words('38.4', lang=language, to='currency', separator=separator,
-                      kobo=False),
+            num2words(
+                '38.4',
+                lang=language,
+                to='currency',
+                separator=separator,
+                kobo=False
+            ),
             "thirty-eight naira and 40 kobo"
         )
         self.assertEqual(
-            num2words('0', lang=language, to='currency', separator=separator,
-                      kobo=False),
+            num2words(
+                '0',
+                lang=language,
+                to='currency',
+                separator=separator,
+                kobo=False
+            ),
             "zero naira and 00 kobo"
         )
 
         self.assertEqual(
-            num2words('1.01', lang=language, to='currency', separator=separator,
-                      kobo=True),
-            "one naira and one cent"
+            num2words(
+                '1.01',
+                lang=language,
+                to='currency',
+                separator=separator,
+                kobo=True
+            ),
+            "one naira and one kobo"
         )
 
         self.assertEqual(
-            num2words('4778.00', lang=language, to='currency', separator=separator,
-                      kobo=True, adjective=True),
+            num2words(
+                '4778.00',
+                lang=language,
+                to='currency',
+                separator=separator,
+                kobo=True, adjective=True
+            ),
             'four thousand, seven hundred and seventy-eight Nigerian naira'
-            ' and zero cents')
+            ' and zero kobo')
 
         self.assertEqual(
-            num2words('4778.00', lang=language, to='currency', separator=separator,
-                      kobo=True),
+            num2words(
+                '4778.00',
+                lang=language,
+                to='currency',
+                separator=separator,
+                kobo=True
+            ),
             'four thousand, seven hundred and seventy-eight naira and'
-            ' zero cents')
+            ' zero kobo')
 
         self.assertEqual(
-            num2words('1.1', lang=language, to='currency', separator=separator,
-                      kobo=True),
+            num2words(
+                '1.1',
+                lang=language,
+                to='currency',
+                separator=separator,
+                kobo=True
+            ),
             "one naira and ten kobo"
         )
 
         self.assertEqual(
-            num2words('158.3', lang=language, to='currency', separator=separator,
-                      kobo=True),
+            num2words(
+                '158.3',
+                lang=language,
+                to='currency',
+                separator=separator,
+                kobo=True
+            ),
             "one hundred and fifty-eight naira and thirty kobo"
         )
 
         self.assertEqual(
-            num2words('2000.00', lang=language, to='currency', separator=separator,
-                      kobo=True),
+            num2words(
+                '2000.00',
+                lang=language,
+                to='currency',
+                separator=separator,
+                kobo=True
+            ),
             "two thousand naira and zero kobo"
         )
 
         self.assertEqual(
-            num2words('4.01', lang=language, to='currency', separator=separator,
-                      kobo=True),
+            num2words(
+                '4.01',
+                lang=language,
+                to='currency',
+                separator=separator,
+                kobo=True
+            ),
             "four naira and one kobo"
         )
 
         self.assertEqual(
-            num2words('2000.00', lang=language, to='currency', separator=separator,
-                      kobo=True),
+            num2words(
+                '2000.00',
+                lang=language,
+                to='currency',
+                separator=separator,
+                kobo=True
+            ),
             "two thousand naira and zero kobo"
         )

--- a/tests/test_en_ng.py
+++ b/tests/test_en_ng.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2003, Taro Ogawa.  All Rights Reserved.
+# Copyright (c) 2013, Savoir-faire Linux inc.  All Rights Reserved.
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301 USA
+
+from unittest import TestCase
+
+from num2words import num2words
+
+
+class Num2WordsENNGTest(TestCase):
+
+    # only the test for currency is writen as other functions in the Class remains the 
+    # same and have been properly tested in the test test_en which tests the parent class
+    # upon which this class inherits
+
+    def test_to_currency(self):
+
+        language = 'en_NG'
+        separator = ' and'
+
+        self.assertEqual(
+            num2words('38.4', lang=language, to='currency', separator=separator,
+                      kobo=False),
+            "thirty-eight naira and 40 kobo"
+        )
+        self.assertEqual(
+            num2words('0', lang=language, to='currency', separator=separator,
+                      kobo=False),
+            "zero naira and 00 kobo"
+        )
+
+        self.assertEqual(
+            num2words('1.01', lang=language, to='currency', separator=separator,
+                      kobo=True),
+            "one naira and one cent"
+        )
+
+        self.assertEqual(
+            num2words('4778.00', lang=language, to='currency', separator=separator,
+                      kobo=True, adjective=True),
+            'four thousand, seven hundred and seventy-eight Nigerian naira'
+            ' and zero cents')
+
+        self.assertEqual(
+            num2words('4778.00', lang=language, to='currency', separator=separator,
+                      kobo=True),
+            'four thousand, seven hundred and seventy-eight naira and'
+            ' zero cents')
+
+        self.assertEqual(
+            num2words('1.1', lang=language, to='currency', separator=separator,
+                      kobo=True),
+            "one naira and ten kobo"
+        )
+
+        self.assertEqual(
+            num2words('158.3', lang=language, to='currency', separator=separator,
+                      kobo=True),
+            "one hundred and fifty-eight naira and thirty kobo"
+        )
+
+        self.assertEqual(
+            num2words('2000.00', lang=language, to='currency', separator=separator,
+                      kobo=True),
+            "two thousand naira and zero kobo"
+        )
+
+        self.assertEqual(
+            num2words('4.01', lang=language, to='currency', separator=separator,
+                      kobo=True),
+            "four naira and one kobo"
+        )
+
+        self.assertEqual(
+            num2words('2000.00', lang=language, to='currency', separator=separator,
+                      kobo=True),
+            "two thousand naira and zero kobo"
+        )


### PR DESCRIPTION

##  Adds Support for the Nigerian Naira as a currency

### Status

- [ ] READY


### How to verify this change

*So all that's required is to set the `lang` attribute to `en_NG`*

### Additional notes

*Hopefully this would be merged into the main branch, when this is done, the language would be represented as en_NG (English - Nigeria)*

