### PR TITLE
Update lang_AM.py: to_currency method currency value to ETB

### DIFF
--- a/num2words/lang_AM.py
+++ b/num2words/lang_AM.py
@@ -116,7 +116,7 @@ class Num2Word_AM(lang_EU.Num2Word_EU):
         self.verify_ordinal(value)
         return '%s%s' % (value, self.to_ordinal(value)[-1:])
 
-    def to_currency(self, val, currency='ብር', cents=True, separator=' ከ',
+    def to_currency(self, val, currency='ETB', cents=True, separator=' ከ',
                     adjective=True):
         result = super(Num2Word_AM, self).to_currency(
             val, currency=currency, cents=cents, separator=separator,


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

* to_currency method error fix.  `currency` value fixed from ብር to ETB

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

```bash
num2words 42.69 -l am --to_currency
```

### Additional notes

to convert currency, the `to_currency` method accepts the currency. For Amharic, Ethiopian birr is ETB.
The code provided ብር which throws an error.

