### PR TITLE
Run tests against Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     'Topic :: Software Development :: Internationalization',
     'Topic :: Software Development :: Libraries :: Python Modules',
     'Topic :: Software Development :: Localization',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,py311,flake8,isort
+envlist = py37,py38,py39,py310,py311,py312,flake8,isort
 
 [gh-actions]
 python =
@@ -8,6 +8,7 @@ python =
 	3.9: py39
 	3.10: isort, flake8, py310
     3.11: py311
+    3.12: py312
 
 
 [testenv]


### PR DESCRIPTION
## Add Support for Python 3.12

### Changes proposed in this pull request:

* Run tests against Python 3.12.
* Add trove classifier.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Run tox 

### Additional notes

Python 3.12 is available since October 2, 2023, see https://blog.python.org/2023/10/python-3120-final-now-available.html.

