### PR TITLE
Switch from the abandoned `docopt` to the maintained `docopt-ng` 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,6 @@ setup(
     test_suite='tests',
     classifiers=CLASSIFIERS,
     scripts=['bin/num2words'],
-    install_requires=["docopt>=0.6.2"],
+    install_requires=["docopt-ng>=0.8.0,<0.9.0"],
     tests_require=['delegator.py'],
 )


### PR DESCRIPTION
### Changes proposed in this pull request:

* Replace the abandoned [`docopt`](https://github.com/docopt/docopt/) dependency with the maintained [`docopt-ng`](https://github.com/jazzband/docopt-ng) fork.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Just run it 🤷🏻 

### Additional notes

`docopt-ng` has been pinned to `<0.9.0`, which contains [a bunch of breaking changes](https://github.com/jazzband/docopt-ng/blob/master/CHANGELOG.md) that might affect `num2words` cli usage.