### PR TITLE
[FIX] ISO code for Belarusian language is be, not by.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ Besides the numerical argument, there are two main optional arguments, ``to:`` a
 * ``am`` (Amharic)
 * ``ar`` (Arabic)
 * ``az`` (Azerbaijani)
-* ``by`` (Belarusian)
+* ``be`` (Belarusian)
 * ``ce`` (Chechen)
 * ``cy`` (Welsh)
 * ``cz`` (Czech)

--- a/num2words/__init__.py
+++ b/num2words/__init__.py
@@ -17,7 +17,7 @@
 
 from __future__ import unicode_literals
 
-from . import (lang_AM, lang_AR, lang_AZ, lang_BY, lang_CE, lang_CY, lang_CZ,
+from . import (lang_AM, lang_AR, lang_AZ, lang_BE, lang_CE, lang_CY, lang_CZ,
                lang_DE, lang_DK, lang_EN, lang_EN_IN, lang_EN_NG, lang_EO,
                lang_ES, lang_ES_CO, lang_ES_CR, lang_ES_GT, lang_ES_NI,
                lang_ES_VE, lang_FA, lang_FI, lang_FR, lang_FR_BE, lang_FR_CH,
@@ -31,7 +31,7 @@ CONVERTER_CLASSES = {
     'am': lang_AM.Num2Word_AM(),
     'ar': lang_AR.Num2Word_AR(),
     'az': lang_AZ.Num2Word_AZ(),
-    'by': lang_BY.Num2Word_BY(),
+    'be': lang_BE.Num2Word_BE(),
     'ce': lang_CE.Num2Word_CE(),
     'cy': lang_CY.Num2Word_CY(),
     'cz': lang_CZ.Num2Word_CZ(),

--- a/num2words/lang_EU.py
+++ b/num2words/lang_EU.py
@@ -53,7 +53,7 @@ class Num2Word_EU(Num2Word_Base):
 
     CURRENCY_ADJECTIVES = {
         'AUD': 'Australian',
-        'BYN': 'Belarussian',
+        'BYN': 'Belarusian',
         'CAD': 'Canadian',
         'EEK': 'Estonian',
         'USD': 'US',

--- a/tests/test_be.py
+++ b/tests/test_be.py
@@ -25,25 +25,25 @@ from num2words import num2words
 
 class Num2WordsBYTest(TestCase):
     def test_cardinal(self):
-        self.assertEqual(num2words(100, lang="by"), "сто")
-        self.assertEqual(num2words(101, lang="by"), "сто адзін")
-        self.assertEqual(num2words(110, lang="by"), "сто дзесяць")
-        self.assertEqual(num2words(115, lang="by"), "сто пятнаццаць")
-        self.assertEqual(num2words(123, lang="by"), "сто дваццаць тры")
-        self.assertEqual(num2words(1000, lang="by"), "адна тысяча")
-        self.assertEqual(num2words(1001, lang="by"), "адна тысяча адзін")
-        self.assertEqual(num2words(2012, lang="by"), "дзве тысячы дванаццаць")
+        self.assertEqual(num2words(100, lang="be"), "сто")
+        self.assertEqual(num2words(101, lang="be"), "сто адзін")
+        self.assertEqual(num2words(110, lang="be"), "сто дзесяць")
+        self.assertEqual(num2words(115, lang="be"), "сто пятнаццаць")
+        self.assertEqual(num2words(123, lang="be"), "сто дваццаць тры")
+        self.assertEqual(num2words(1000, lang="be"), "адна тысяча")
+        self.assertEqual(num2words(1001, lang="be"), "адна тысяча адзін")
+        self.assertEqual(num2words(2012, lang="be"), "дзве тысячы дванаццаць")
         self.assertEqual(
-            num2words(12519.85, lang="by"),
+            num2words(12519.85, lang="be"),
             "дванаццаць тысяч пяцьсот дзевятнаццаць коска восемдзесят пяць",
         )
         self.assertEqual(
-            num2words(1234567890, lang="by"),
+            num2words(1234567890, lang="be"),
             "адзін мільярд дзвесце трыццаць чатыры мільёны пяцьсот "
             "шэсцьдзясят сем тысяч восемсот дзевяноста",
         )
         self.assertEqual(
-            num2words(461407892039002157189883901676, lang="by"),
+            num2words(461407892039002157189883901676, lang="be"),
             "чатырыста шэсцьдзясят адзін "
             "актыльён чатырыста сем сэптыльёнаў восемсот дзевяноста "
             "два секстыльёны трыццаць дзевяць квінтыльёнаў два квадрыльёны "
@@ -52,7 +52,7 @@ class Num2WordsBYTest(TestCase):
             "шэсцьсот семдзесят шэсць",
         )
         self.assertEqual(
-            num2words(94234693663034822824384220291, lang="by"),
+            num2words(94234693663034822824384220291, lang="be"),
             "дзевяноста чатыры актыльёны "
             "дзвесце трыццаць чатыры сэптыльёны шэсцьсот дзевяноста тры "
             "секстыльёны шэсцьсот шэсцьдзясят тры квінтыльёны трыццаць "
@@ -60,250 +60,280 @@ class Num2WordsBYTest(TestCase):
             "дваццаць чатыры мільярды трыста восемдзесят чатыры мільёны "
             "дзвесце дваццаць тысяч дзвесце дзевяноста адзін",
         )
-        self.assertEqual(num2words(5, lang="by"), "пяць")
-        self.assertEqual(num2words(15, lang="by"), "пятнаццаць")
-        self.assertEqual(num2words(154, lang="by"), "сто пяцьдзясят чатыры")
+        self.assertEqual(num2words(5, lang="be"), "пяць")
+        self.assertEqual(num2words(15, lang="be"), "пятнаццаць")
+        self.assertEqual(num2words(154, lang="be"), "сто пяцьдзясят чатыры")
         self.assertEqual(
-            num2words(1135, lang="by"), "адна тысяча сто трыццаць пяць"
+            num2words(1135, lang="be"), "адна тысяча сто трыццаць пяць"
         )
         self.assertEqual(
-            num2words(418531, lang="by"),
+            num2words(418531, lang="be"),
             "чатырыста васямнаццаць тысяч пяцьсот трыццаць адзін",
         )
         self.assertEqual(
-            num2words(1000139, lang="by"), "адзін мільён сто трыццаць дзевяць"
+            num2words(1000139, lang="be"), "адзін мільён сто трыццаць дзевяць"
         )
-        self.assertEqual(num2words(-1, lang="by"), "мінус адзін")
-        self.assertEqual(num2words(-15, lang="by"), "мінус пятнаццаць")
-        self.assertEqual(num2words(-100, lang="by"), "мінус сто")
+        self.assertEqual(num2words(-1, lang="be"), "мінус адзін")
+        self.assertEqual(num2words(-15, lang="be"), "мінус пятнаццаць")
+        self.assertEqual(num2words(-100, lang="be"), "мінус сто")
 
     def test_floating_point(self):
-        self.assertEqual(num2words(5.2, lang="by"), "пяць коска два")
-        self.assertEqual(num2words(10.02, lang="by"), "дзесяць коска нуль два")
+        self.assertEqual(num2words(5.2, lang="be"), "пяць коска два")
+        self.assertEqual(num2words(10.02, lang="be"), "дзесяць коска нуль два")
         self.assertEqual(
-            num2words(15.007, lang="by"), "пятнаццаць коска нуль нуль сем"
+            num2words(15.007, lang="be"), "пятнаццаць коска нуль нуль сем"
         )
         self.assertEqual(
-            num2words(561.42, lang="by"),
+            num2words(561.42, lang="be"),
             "пяцьсот шэсцьдзясят адзін коска сорак два",
         )
 
         self.assertEqual(
-            num2words(561.0, lang="by"), "пяцьсот шэсцьдзясят адзін коска нуль"
+            num2words(561.0, lang="be"), "пяцьсот шэсцьдзясят адзін коска нуль"
         )
 
     def test_to_ordinal(self):
-        self.assertEqual(num2words(1, lang="by", to="ordinal"), "першы")
-        self.assertEqual(num2words(5, lang="by", to="ordinal"), "пяты")
-        self.assertEqual(num2words(6, lang="by", to="ordinal"), "шосты")
-        self.assertEqual(num2words(10, lang="by", to="ordinal"), "дзясяты")
+        self.assertEqual(num2words(1, lang="be", to="ordinal"), "першы")
+        self.assertEqual(num2words(5, lang="be", to="ordinal"), "пяты")
+        self.assertEqual(num2words(6, lang="be", to="ordinal"), "шосты")
+        self.assertEqual(num2words(10, lang="be", to="ordinal"), "дзясяты")
 
-        self.assertEqual(num2words(13, lang="by", to="ordinal"), "трынаццаты")
-        self.assertEqual(num2words(20, lang="by", to="ordinal"), "дваццаты")
+        self.assertEqual(num2words(13, lang="be", to="ordinal"), "трынаццаты")
+        self.assertEqual(num2words(20, lang="be", to="ordinal"), "дваццаты")
         self.assertEqual(
-            num2words(23, lang="by", to="ordinal"), "дваццаць трэці"
+            num2words(23, lang="be", to="ordinal"), "дваццаць трэці"
         )
         self.assertEqual(
-            num2words(23, lang="by", to="ordinal", gender="f"),
+            num2words(23, lang="be", to="ordinal", gender="f"),
             "дваццаць трэцяя",
         )
         self.assertEqual(
-            num2words(23, lang="by", to="ordinal", gender="n"),
+            num2words(23, lang="be", to="ordinal", gender=True),
+            "дваццаць трэцяя",
+        )
+        self.assertEqual(
+            num2words(23, lang="be", to="ordinal", gender="n"),
             "дваццаць трэцяе",
         )
-        self.assertEqual(num2words(40, lang="by", to="ordinal"), "саракавы")
         self.assertEqual(
-            num2words(61, lang="by", to="ordinal"), "шэсцьдзясят першы"
+            num2words(46, lang="be", to="ordinal", gender="m"),
+            "сорак шосты",
         )
-        self.assertEqual(num2words(70, lang="by", to="ordinal"), "сямідзясяты")
-        self.assertEqual(num2words(100, lang="by", to="ordinal"), "соты")
+        self.assertEqual(num2words(40, lang="be", to="ordinal"), "саракавы")
         self.assertEqual(
-            num2words(136, lang="by", to="ordinal"), "сто трыццаць шосты"
+            num2words(61, lang="be", to="ordinal"), "шэсцьдзясят першы"
         )
-        self.assertEqual(num2words(500, lang="by", to="ordinal"), "пяцісоты")
+        self.assertEqual(num2words(70, lang="be", to="ordinal"), "сямідзясяты")
+        self.assertEqual(num2words(100, lang="be", to="ordinal"), "соты")
+        self.assertEqual(
+            num2words(136, lang="be", to="ordinal"), "сто трыццаць шосты"
+        )
+        self.assertEqual(num2words(500, lang="be", to="ordinal"), "пяцісоты")
 
         self.assertEqual(
-            num2words(500, lang="by", to="ordinal", gender="f"), "пяцісотая"
-        )
-
-        self.assertEqual(
-            num2words(500, lang="by", to="ordinal", gender="n"), "пяцісотае"
-        )
-
-        self.assertEqual(num2words(1000, lang="by", to="ordinal"), "тысячны")
-
-        self.assertEqual(
-            num2words(1000, lang="by", to="ordinal", gender="f"), "тысячная"
+            num2words(500, lang="be", to="ordinal", gender="f"), "пяцісотая"
         )
 
         self.assertEqual(
-            num2words(1000, lang="by", to="ordinal", gender="n"), "тысячнае"
+            num2words(500, lang="be", to="ordinal", gender="n"), "пяцісотае"
+        )
+
+        self.assertEqual(num2words(1000, lang="be", to="ordinal"), "тысячны")
+
+        self.assertEqual(
+            num2words(1000, lang="be", to="ordinal", gender="f"), "тысячная"
         )
 
         self.assertEqual(
-            num2words(1001, lang="by", to="ordinal"), "тысяча першы"
+            num2words(1000, lang="be", to="ordinal", gender="n"), "тысячнае"
+        )
+
+        self.assertEqual(
+            num2words(1001, lang="be", to="ordinal"), "тысяча першы"
         )
         self.assertEqual(
-            num2words(2000, lang="by", to="ordinal"), "двухтысячны"
+            num2words(3000, lang="be", to="ordinal"), "трохтысячны"
         )
         self.assertEqual(
-            num2words(10000, lang="by", to="ordinal"), "дзесяцітысячны"
+            num2words(10000, lang="be", to="ordinal"), "дзесяцітысячны"
         )
         self.assertEqual(
-            num2words(42000, lang="by", to="ordinal"), "саракадвухтысячны"
+            num2words(30000, lang="be", to="ordinal"), "трыццацітысячны"
         )
         self.assertEqual(
-            num2words(1000000, lang="by", to="ordinal"), "мільённы"
+            num2words(42000, lang="be", to="ordinal"), "саракадвухтысячны"
+        )
+
+        self.assertEqual(
+            num2words(75000, lang="be", to="ordinal"), "сямідзесяціпяцітысячны"
+        )
+
+        self.assertEqual(
+            num2words(1000000, lang="be", to="ordinal"), "мільённы"
         )
         self.assertEqual(
-            num2words(1000000000, lang="by", to="ordinal"), "мільярдны"
+            num2words(30000000, lang="be", to="ordinal"), "трыццацімільённы"
+        )
+        self.assertEqual(
+            num2words(1000000000, lang="be", to="ordinal"), "мільярдны"
+        )
+        self.assertEqual(
+            num2words(3000000000, lang="be", to="ordinal"), "трохмільярдны"
+        )
+        self.assertEqual(
+            num2words(43000000000, lang="be", to="ordinal"),
+            "саракатрохмільярдны",
+        )
+        self.assertEqual(
+            num2words(333000000000, lang="be", to="ordinal"),
+            "трыстатрыццацітрохмільярдны",
         )
 
     def test_to_currency(self):
         self.assertEqual(
-            num2words(1.0, lang="by", to="currency", currency="EUR"),
+            num2words(1.0, lang="be", to="currency", currency="EUR"),
             "адзін еўра, нуль цэнтаў",
         )
         self.assertEqual(
-            num2words(1.0, lang="by", to="currency", currency="RUB"),
+            num2words(1.0, lang="be", to="currency", currency="RUB"),
             "адзін расійскі рубель, нуль капеек",
         )
         self.assertEqual(
-            num2words(1.0, lang="by", to="currency", currency="BYN"),
+            num2words(1.0, lang="be", to="currency", currency="BYN"),
             "адзін беларускі рубель, нуль капеек",
         )
         self.assertEqual(
-            num2words(1.0, lang="by", to="currency", currency="UAH"),
+            num2words(1.0, lang="be", to="currency", currency="UAH"),
             "адна грыўна, нуль капеек",
         )
         self.assertEqual(
-            num2words(1234.56, lang="by", to="currency", currency="EUR"),
+            num2words(1234.56, lang="be", to="currency", currency="EUR"),
             "адна тысяча дзвесце трыццаць чатыры еўра, "
             "пяцьдзясят шэсць цэнтаў",
         )
         self.assertEqual(
-            num2words(1234.56, lang="by", to="currency", currency="RUB"),
+            num2words(1234.56, lang="be", to="currency", currency="RUB"),
             "адна тысяча дзвесце трыццаць чатыры расійскія рублі, "
             "пяцьдзясят шэсць капеек",
         )
         self.assertEqual(
-            num2words(1234.56, lang="by", to="currency", currency="BYN"),
+            num2words(1234.56, lang="be", to="currency", currency="BYN"),
             "адна тысяча дзвесце трыццаць чатыры беларускія рублі, "
             "пяцьдзясят шэсць капеек",
         )
         self.assertEqual(
-            num2words(1234.56, lang="by", to="currency", currency="UAH"),
+            num2words(1234.56, lang="be", to="currency", currency="UAH"),
             "адна тысяча дзвесце трыццаць чатыры грыўны, "
             "пяцьдзясят шэсць капеек",
         )
         self.assertEqual(
             num2words(
-                10111, lang="by", to="currency", currency="EUR", separator=" і"
+                10111, lang="be", to="currency", currency="EUR", separator=" і"
             ),
             "сто адзін еўра і адзінаццаць цэнтаў",
         )
         self.assertEqual(
             num2words(
-                10111, lang="by", to="currency", currency="RUB", separator=" і"
+                10111, lang="be", to="currency", currency="RUB", separator=" і"
             ),
             "сто адзін расійскі рубель і адзінаццаць капеек",
         )
         self.assertEqual(
             num2words(
-                10111, lang="by", to="currency", currency="BYN", separator=" і"
+                10111, lang="be", to="currency", currency="BYN", separator=" і"
             ),
             "сто адзін беларускі рубель і адзінаццаць капеек",
         )
         self.assertEqual(
             num2words(
-                10111, lang="by", to="currency", currency="UAH", separator=" і"
+                10111, lang="be", to="currency", currency="UAH", separator=" і"
             ),
             "сто адна грыўна і адзінаццаць капеек",
         )
         self.assertEqual(
             num2words(
-                10121, lang="by", to="currency", currency="EUR", separator=" і"
+                10121, lang="be", to="currency", currency="EUR", separator=" і"
             ),
             "сто адзін еўра і дваццаць адзін цэнт",
         )
         self.assertEqual(
             num2words(
-                10121, lang="by", to="currency", currency="RUB", separator=" і"
+                10121, lang="be", to="currency", currency="RUB", separator=" і"
             ),
             "сто адзін расійскі рубель і дваццаць адна капейка",
         )
         self.assertEqual(
             num2words(
-                10121, lang="by", to="currency", currency="BYN", separator=" і"
+                10121, lang="be", to="currency", currency="BYN", separator=" і"
             ),
             "сто адзін беларускі рубель і дваццаць адна капейка",
         )
         self.assertEqual(
             num2words(
-                10121, lang="by", to="currency", currency="UAH", separator=" і"
+                10121, lang="be", to="currency", currency="UAH", separator=" і"
             ),
             "сто адна грыўна і дваццаць адна капейка",
         )
         self.assertEqual(
             num2words(
-                10122, lang="by", to="currency", currency="EUR", separator=" і"
+                10122, lang="be", to="currency", currency="EUR", separator=" і"
             ),
             "сто адзін еўра і дваццаць два цэнты",
         )
         self.assertEqual(
             num2words(
-                10122, lang="by", to="currency", currency="RUB", separator=" і"
+                10122, lang="be", to="currency", currency="RUB", separator=" і"
             ),
             "сто адзін расійскі рубель і дваццаць дзве капейкі",
         )
         self.assertEqual(
             num2words(
-                10122, lang="by", to="currency", currency="BYN", separator=" і"
+                10122, lang="be", to="currency", currency="BYN", separator=" і"
             ),
             "сто адзін беларускі рубель і дваццаць дзве капейкі",
         )
         self.assertEqual(
             num2words(
-                10122, lang="by", to="currency", currency="UAH", separator=" і"
+                10122, lang="be", to="currency", currency="UAH", separator=" і"
             ),
             "сто адна грыўна і дваццаць дзве капейкі",
         )
         self.assertEqual(
             num2words(
-                10122, lang="by", to="currency", currency="KZT", separator=" і"
+                10122, lang="be", to="currency", currency="KZT", separator=" і"
             ),
             "сто адзін тэнге і дваццаць два тыйіны",
         )
         self.assertEqual(
             num2words(
-                -1251985, lang="by", to="currency", currency="EUR", cents=False
+                -1251985, lang="be", to="currency", currency="EUR", cents=False
             ),
             "мінус дванаццаць тысяч пяцьсот дзевятнаццаць еўра, 85 цэнтаў",
         )
         self.assertEqual(
             num2words(
-                -1251985, lang="by", to="currency", currency="RUB", cents=False
+                -1251985, lang="be", to="currency", currency="RUB", cents=False
             ),
             "мінус дванаццаць тысяч пяцьсот дзевятнаццаць "
             "расійскіх рублёў, 85 капеек",
         )
         self.assertEqual(
             num2words(
-                -1251985, lang="by", to="currency", currency="BYN", cents=False
+                -1251985, lang="be", to="currency", currency="BYN", cents=False
             ),
             "мінус дванаццаць тысяч пяцьсот дзевятнаццаць "
             "беларускіх рублёў, 85 капеек",
         )
         self.assertEqual(
             num2words(
-                -1251985, lang="by", to="currency", currency="UAH", cents=False
+                -1251985, lang="be", to="currency", currency="UAH", cents=False
             ),
             "мінус дванаццаць тысяч пяцьсот дзевятнаццаць грыўнаў, 85 капеек",
         )
         self.assertEqual(
             num2words(
                 "38.4",
-                lang="by",
+                lang="be",
                 to="currency",
                 separator=" і",
                 cents=False,
@@ -314,7 +344,7 @@ class Num2WordsBYTest(TestCase):
         self.assertEqual(
             num2words(
                 "38.4",
-                lang="by",
+                lang="be",
                 to="currency",
                 separator=" і",
                 cents=False,
@@ -325,7 +355,7 @@ class Num2WordsBYTest(TestCase):
         self.assertEqual(
             num2words(
                 "38.4",
-                lang="by",
+                lang="be",
                 to="currency",
                 separator=" і",
                 cents=False,
@@ -334,22 +364,38 @@ class Num2WordsBYTest(TestCase):
             "трыццаць восем грыўнаў і 40 капеек",
         )
         self.assertEqual(
-            num2words("1230.56", lang="by", to="currency", currency="USD"),
+            num2words("1230.56", lang="be", to="currency", currency="USD"),
             "адна тысяча дзвесце трыццаць долараў, пяцьдзясят шэсць цэнтаў",
         )
         self.assertEqual(
-            num2words("1231.56", lang="by", to="currency", currency="USD"),
+            num2words("1231.56", lang="be", to="currency", currency="USD"),
             "адна тысяча дзвесце трыццаць адзін долар, "
             "пяцьдзясят шэсць цэнтаў",
         )
         self.assertEqual(
-            num2words("1234.56", lang="by", to="currency", currency="USD"),
+            num2words("1234.56", lang="be", to="currency", currency="USD"),
             "адна тысяча дзвесце трыццаць чатыры долары, пяцьдзясят шэсць "
             "цэнтаў",
         )
         self.assertEqual(
             num2words(
-                10122, lang="by", to="currency", currency="UZS", separator=" і"
+                10122, lang="be", to="currency", currency="UZS", separator=" і"
             ),
             "сто адзін сум і дваццаць два тыйіны",
+        )
+
+        self.assertEqual(
+            num2words(1.0, lang="be", to="currency", currency="PLN"),
+            "адзін злоты, нуль грошаў",
+        )
+
+        self.assertEqual(
+            num2words(23.40, lang="be", to="currency", currency="PLN"),
+            "дваццаць тры злотых, сорак грошаў",
+        )
+
+        self.assertEqual(
+            num2words(9999.39, lang="be", to="currency", currency="PLN"),
+            "дзевяць тысяч дзевяцьсот дзевяноста дзевяць злотых, "
+            "трыццаць дзевяць грошаў",
         )


### PR DESCRIPTION
## Fixes of ISO code for Belarusian

### Changes proposed in this pull request:
 ISO code for Belarusian language is be, not by.

### Status

- [X ] READY

### How to verify this change
https://lh.2xlibre.net/locale/be_BY/

