### PR TITLE
Correct currency from dinard to dinar

### DIFF
--- a/num2words/lang_FR_DZ.py
+++ b/num2words/lang_FR_DZ.py
@@ -22,7 +22,7 @@ from .lang_FR import Num2Word_FR
 
 class Num2Word_FR_DZ(Num2Word_FR):
     CURRENCY_FORMS = {
-        'DIN': (('dinard', 'dinards'), ('centime', 'centimes')),
+        'DIN': (('dinar', 'dinars'), ('centime', 'centimes')),
     }
 
     def to_currency(self, val, currency='DIN', cents=True, separator=' et',


### PR DESCRIPTION
Algerian currency is "Dinar" not "Dinard". There is no "d" in it therefore a correction is needed. 

## Fixes 

Fixes the currency name by remove the trailing 'd'


### Changes proposed in this pull request:

* A correction in the name of the currency 'fr_DZ'

### Status

- [X ] READY
- [ ] HOLD
- [] WIP (Work-In-Progress)

### How to verify this change

A quick search on the web will confirm this.
For reference: 
https://en.wikipedia.org/wiki/Algerian_dinar


### Additional notes

If the current output is kept, the result will be wrong. Working with official documents is not possible since they'll be denied. 
