### PR TITLE
Fixed Amharic Infinite Loop for 568476685 and Other Large Numbers

### DIFF
--- a/num2words/lang_AM.py
+++ b/num2words/lang_AM.py
@@ -98,6 +98,7 @@ class Num2Word_AM(lang_EU.Num2Word_EU):
             return '%s %s' % (ltext, rtext), lnum + rnum
         elif rnum > lnum:
             return '%s %s' % (ltext, rtext), lnum * rnum
+        return ("%s, %s" % (ltext, rtext), lnum + rnum)
 
     def to_ordinal(self, value):
         self.verify_ordinal(value)

--- a/tests/test_am.py
+++ b/tests/test_am.py
@@ -25,6 +25,12 @@ class Num2WordsAMTest(TestCase):
         self.assertEqual(num2words(100, lang='am'), 'መቶ')
         self.assertEqual(num2words(100000, lang='am'), 'አንድ መቶ ሺህ')
         self.assertEqual(num2words(101, lang='am'), 'አንድ መቶ አንድ')
+        self.assertEqual(num2words(568476685, lang='am'), 'አምስት መቶ ስድሳ ስምንት mሚሊዮን, አራት መቶ ሰባ ስድስት ሺህ, ስድስት መቶ ሰማኒያ አምስት')
+        self.assertEqual(num2words(56847, lang='am'), 'አምሳ ስድስት ሺህ, ስምንት መቶ አርባ ሰባት')
+        self.assertEqual(num2words(1111111111111111111, lang='am'), 'አንድ quintሚሊዮን, አንድ መቶ አሥራ አንድ quadrሚሊዮን, አንድ መቶ አሥራ አንድ trሚሊዮን, አንድ መቶ አሥራ አንድ bቢሊዮን, አንድ መቶ አሥራ አንድ mሚሊዮን, አንድ መቶ አሥራ አንድ ሺህ, አንድ መቶ አሥራ አንድ')
+        self.assertEqual(num2words(999999999, lang='am'), 'ዘጠኝ መቶ ዘጠና ዘጠኝ mሚሊዮን, ዘጠኝ መቶ ዘጠና ዘጠኝ ሺህ, ዘጠኝ መቶ ዘጠና ዘጠኝ')
+        self.assertEqual(num2words(29498237468376240, lang="am"), 'ሃያ ዘጠኝ quadrሚሊዮን, አራት መቶ ዘጠና ስምንት trሚሊዮን, ሁለት መቶ ሠላሳ ሰባት bቢሊዮን, አራት መቶ ስድሳ ስምንት mሚሊዮን, ሦስት መቶ ሰባ ስድስት ሺህ, ሁለት መቶ አርባ')
+        self.assertEqual(num2words(110110, lang='am'), 'አንድ መቶ አሥር ሺህ, አንድ መቶ አሥር')
 
     def test_and_join_199(self):
         self.assertEqual(num2words(199, lang='am'), 'አንድ መቶ ዘጠና ዘጠኝ')


### PR DESCRIPTION
## Fixes # by..

### Changes proposed in this pull request:

* Added return statement in merge function after the elifs to ensure that recursive combinations are resolved properly. Any situation not explicitly handled by the existing conditions will be covered by the added return statement, which will prevent the merge logic from entering an undefined or recursive state.
* Added tests in tests_am.py to ensure the bug was fixed as well as added additional tests to ensure proper handling of large numbers and ones with irregular splits in the Amharic language.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Test with num2words(568476685, lang="am") or "num2words 568476685 -l am" in the command line. Can also run the test_am.py file to check with test case/assert statement.

### Additional notes

Fixed Issue #591

