### PR TITLE
Adjusted handling for big numbers in Portuguese and Spanish

### DIFF
--- a/num2words/lang_ES.py
+++ b/num2words/lang_ES.py
@@ -208,12 +208,19 @@ class Num2Word_ES(Num2Word_EU):
         'ZWL': (GENERIC_DOLLARS, ('céntimo', 'céntimos')),
     }
 
-    # //CHECK: Is this sufficient??
     GIGA_SUFFIX = None
     MEGA_SUFFIX = "illón"
 
+    def set_high_numwords(self, high):
+        max = 3 + 3 * len(high)
+        for word, n in zip(high, range(max, 3, -3)):
+            if n % 6 == 0:
+                self.cards[10 ** n] = word + self.MEGA_SUFFIX 
+            else:
+                self.cards[10 ** n] = "mil " + word + self.MEGA_SUFFIX
+
     def setup(self):
-        lows = ["cuatr", "tr", "b", "m"]
+        lows = ["cuatr", "cuatr", "tr", "tr", "b", "b", "m", "m"]
         self.high_numwords = self.gen_high_numwords([], [], lows)
         self.negword = "menos "
         self.pointword = "punto"
@@ -277,15 +284,21 @@ class Num2Word_ES(Num2Word_EU):
         if cnum == 1:
             if nnum < 1000000:
                 return next
-            ctext = "un"
+            if nnum >= 1000000000 and "mil " in ntext:
+                ctext = ""
+            else:
+                ctext = "un"
         elif cnum == 100 and not nnum % 1000 == 0:
             ctext += "t" + self.gender_stem
 
         if nnum < cnum:
-            if cnum < 100:
+            if cnum == 1000000000 and nnum > 1:
+                ctext = ctext[:-3] + "lones"
+            elif cnum < 100: 
                 return "%s y %s" % (ctext, ntext), cnum + nnum
             return "%s %s" % (ctext, ntext), cnum + nnum
-        elif (not nnum % 1000000) and cnum > 1:
+
+        if (nnum % 1000000 == 0 and cnum > 1) or (nnum >= 1000000000 and "mil " in ntext):
             ntext = ntext[:-3] + "lones"
 
         if nnum == 100:
@@ -300,6 +313,10 @@ class Num2Word_ES(Num2Word_EU):
         else:
             ntext = " " + ntext
 
+        if ctext == "":
+            result = " ".join([ctext, ntext])
+            result = result.strip()
+            return (result, cnum * nnum)
         return (ctext + ntext, cnum * nnum)
 
     def to_ordinal(self, value):

--- a/num2words/lang_PT.py
+++ b/num2words/lang_PT.py
@@ -38,9 +38,17 @@ class Num2Word_PT(Num2Word_EU):
     GIGA_SUFFIX = None
     MEGA_SUFFIX = "ilião"
 
+    def set_high_numwords(self, high):
+        max = 3 + 3 * len(high)
+        for word, n in zip(high, range(max, 3, -3)):
+            if n % 6 == 0:
+                self.cards[10 ** n] = word + self.MEGA_SUFFIX 
+            else:
+                self.cards[10 ** n] = "mil " + word + self.MEGA_SUFFIX
+            
     def setup(self):
         super(Num2Word_PT, self).setup()
-        lows = ["quatr", "tr", "b", "m"]
+        lows = ["quatr", "quatr", "tr", "tr", "b", "b", "m", "m"]
         self.high_numwords = self.gen_high_numwords([], [], lows)
         self.negword = "menos "
         self.pointword = "vírgula"
@@ -120,7 +128,11 @@ class Num2Word_PT(Num2Word_EU):
         if cnum == 1:
             if nnum < 1000000:
                 return next
-            ctext = "um"
+            if nnum < 1000000 or "mil " not in ntext:
+                ctext = "um"
+            else:
+                ctext = ""
+
         elif cnum == 100 and not nnum % 1000 == 0:
             ctext = "cento"
 
@@ -129,13 +141,15 @@ class Num2Word_PT(Num2Word_EU):
                 return ("%s e %s" % (ctext, ntext), cnum + nnum)
             return ("%s e %s" % (ctext, ntext), cnum + nnum)
 
-        elif (not nnum % 1000000000) and cnum > 1:
+        elif ((not nnum % 1000000000) and cnum > 1) or ctext == "":
             ntext = ntext[:-4] + "liões"
         elif (not nnum % 1000000) and cnum > 1:
             ntext = ntext[:-4] + "lhões"
         # correct "milião" to "milhão"
         if ntext == 'milião':
             ntext = 'milhão'
+        elif 'miliões' in ntext:
+            ntext = ntext.replace('miliões', 'milhões')
         if nnum == 100:
             ctext = self.hundreds[cnum]
             ntext = ""
@@ -143,7 +157,7 @@ class Num2Word_PT(Num2Word_EU):
         else:
             ntext = " " + ntext
 
-        return (ctext + ntext, cnum * nnum)
+        return ((ctext + ntext).strip(), cnum * nnum)
 
     def to_cardinal(self, value):
         result = super(Num2Word_PT, self).to_cardinal(value)

--- a/num2words/lang_PT_BR.py
+++ b/num2words/lang_PT_BR.py
@@ -34,6 +34,9 @@ class Num2Word_PT_BR(lang_PT.Num2Word_PT):
         self.low_numwords[3] = 'dezessete'
         self.low_numwords[4] = 'dezesseis'
 
+        lows = ["quatr", "tr", "b", "m"]
+        self.high_numwords = self.gen_high_numwords([], [], lows)
+
         self.thousand_separators = {
             3: "milésimo",
             6: "milionésimo",

--- a/tests/test_pt.py
+++ b/tests/test_pt.py
@@ -83,10 +83,26 @@ class Num2WordsPTTest(TestCase):
             num2words(73421, lang='pt'),
             'setenta e três mil quatrocentos e vinte e um'
         )
-        self.assertEqual(num2words(100000, lang='pt'), 'cem mil')
+        self.assertEqual(
+            num2words(100000, lang='pt'), 
+            'cem mil'
+        )
+        self.assertEqual(
+            num2words(1000014, lang='pt'),
+            'um milhão e catorze'
+        )
+        self.assertEqual(
+            num2words(1001000, lang='pt'), 
+            'um milhão e mil'
+        )
+
         self.assertEqual(
             num2words(250050, lang='pt'),
             'duzentos e cinquenta mil e cinquenta'
+        )
+        self.assertEqual(
+            num2words(4000014, lang='pt'),
+            'quatro milhões e catorze'
         )
         self.assertEqual(
             num2words(6000000, lang='pt'), 'seis milhões'
@@ -107,7 +123,7 @@ class Num2WordsPTTest(TestCase):
         )
         self.assertEqual(
             num2words(145254635102, lang='pt'),
-            'cento e quarenta e cinco mil duzentos e cinquenta e quatro '
+            'cento e quarenta e cinco mil milhões duzentos e cinquenta e quatro '
             'milhões seiscentos e trinta e cinco mil cento e dois'
         )
         self.assertEqual(
@@ -134,6 +150,26 @@ class Num2WordsPTTest(TestCase):
             num2words(2000000000000000000, lang='pt'),
             'dois triliões'
         )
+        self.assertEqual(
+            num2words(1000000000000000000000000001, lang='pt'),
+            'mil quatriliões e um'
+        )
+        self.assertEqual(
+            num2words(11111111111111111111111111111, lang='pt'),
+            'onze mil quatriliões e cento e onze quatriliões '
+            'e cento e onze mil triliões e cento e onze triliões '
+            'e cento e onze mil biliões cento e onze biliões cento e onze '
+            'mil milhões cento e onze milhões cento e onze mil cento e onze'
+        )
+        self.assertEqual(
+            num2words(500000000000000000000000000, lang='pt'),
+            'quinhentos quatriliões'
+        )
+        self.assertEqual(
+            num2words(900000000000000000000000000009, lang='pt'),
+            'novecentos mil quatriliões e nove'
+        )
+
 
     def test_cardinal_integer_negative(self):
         self.assertEqual(num2words(-1, lang='pt'), 'menos um')


### PR DESCRIPTION

## Fixes #501  by adjusting the lows array in both Portuguese and Spanish files, so that the file no longer goes over the length of the array and incorrectly says that the inputted number is larger than the max value. 

### Changes proposed in this pull request:

* Override the inherited set_high_numwords function in lang_EU.py in Portuguese (PT and PT_BR) and Spanish (ES)
* Adjust the lows[] array of languages to account for naming conventions
* Add new Portuguese translation tests
* Fix one Portuguese test that incorrectly translated 

### Status

- [X] READY
- [ ] HOLD
- [] WIP (Work-In-Progress)

### How to verify this change

Input any number between 0 - one nonillion to Spanish or Portuguese and ensure the translation is correct. Can also run the test file to verify this change in Portuguese. 

### Additional notes
This change edited the lows array because billions/quadrillions/sextillions in Spanish/Portuguese have the same root word as the power of ten before it, but with 'mil' added in front. EX in Spanish: (milion = "millón", billion = "mil millón", trillion = "billón", quadrillion = "mil billón"). 

