### PR TITLE
Fixed Currency to only Display Cents When Needed

### DIFF
--- a/num2words/base.py
+++ b/num2words/base.py
@@ -267,7 +267,7 @@ class Num2Word_Base(object):
         return "%02d" % number
 
     def to_currency(self, val, currency='EUR', cents=True, separator=',',
-                    adjective=False):
+                adjective=False):
         """
         Args:
             val: Numeric value
@@ -278,6 +278,7 @@ class Num2Word_Base(object):
         Returns:
             str: Formatted string
 
+        Handles whole numbers and decimal numbers differently
         """
         left, right, is_negative = parse_currency_parts(val)
 
@@ -294,17 +295,31 @@ class Num2Word_Base(object):
 
         minus_str = "%s " % self.negword.strip() if is_negative else ""
         money_str = self._money_verbose(left, currency)
-        cents_str = self._cents_verbose(right, currency) \
-            if cents else self._cents_terse(right, currency)
 
-        return u'%s%s %s%s %s %s' % (
-            minus_str,
-            money_str,
-            self.pluralize(left, cr1),
-            separator,
-            cents_str,
-            self.pluralize(right, cr2)
-        )
+        # Explicitly check if input has decimal point or non-zero cents
+        has_decimal = isinstance(val, float) or str(val).find('.') != -1
+
+        # Only include cents if:
+        # 1. Input has decimal point OR
+        # 2. Cents are non-zero
+        if has_decimal or right > 0:
+            cents_str = self._cents_verbose(right, currency) \
+                if cents else self._cents_terse(right, currency)
+            
+            return u'%s%s %s%s %s %s' % (
+                minus_str,
+                money_str,
+                self.pluralize(left, cr1),
+                separator,
+                cents_str,
+                self.pluralize(right, cr2)
+            )
+        else:
+            return u'%s%s %s' % (
+                minus_str,
+                money_str,
+                self.pluralize(left, cr1)
+            )
 
     def setup(self):
         pass

--- a/tests/test_am.py
+++ b/tests/test_am.py
@@ -25,6 +25,12 @@ class Num2WordsAMTest(TestCase):
         self.assertEqual(num2words(100, lang='am'), 'መቶ')
         self.assertEqual(num2words(100000, lang='am'), 'አንድ መቶ ሺህ')
         self.assertEqual(num2words(101, lang='am'), 'አንድ መቶ አንድ')
+        self.assertEqual(num2words(568476685, lang='am'), 'አምስት መቶ ስድሳ ስምንት mሚሊዮን, አራት መቶ ሰባ ስድስት ሺህ, ስድስት መቶ ሰማኒያ አምስት')
+        self.assertEqual(num2words(56847, lang='am'), 'አምሳ ስድስት ሺህ, ስምንት መቶ አርባ ሰባት')
+        self.assertEqual(num2words(1111111111111111111, lang='am'), 'አንድ quintሚሊዮን, አንድ መቶ አሥራ አንድ quadrሚሊዮን, አንድ መቶ አሥራ አንድ trሚሊዮን, አንድ መቶ አሥራ አንድ bቢሊዮን, አንድ መቶ አሥራ አንድ mሚሊዮን, አንድ መቶ አሥራ አንድ ሺህ, አንድ መቶ አሥራ አንድ')
+        self.assertEqual(num2words(999999999, lang='am'), 'ዘጠኝ መቶ ዘጠና ዘጠኝ mሚሊዮን, ዘጠኝ መቶ ዘጠና ዘጠኝ ሺህ, ዘጠኝ መቶ ዘጠና ዘጠኝ')
+        self.assertEqual(num2words(29498237468376240, lang="am"), 'ሃያ ዘጠኝ quadrሚሊዮን, አራት መቶ ዘጠና ስምንት trሚሊዮን, ሁለት መቶ ሠላሳ ሰባት bቢሊዮን, አራት መቶ ስድሳ ስምንት mሚሊዮን, ሦስት መቶ ሰባ ስድስት ሺህ, ሁለት መቶ አርባ')
+        self.assertEqual(num2words(110110, lang='am'), 'አንድ መቶ አሥር ሺህ, አንድ መቶ አሥር')
 
     def test_and_join_199(self):
         self.assertEqual(num2words(199, lang='am'), 'አንድ መቶ ዘጠና ዘጠኝ')
@@ -73,7 +79,7 @@ class Num2WordsAMTest(TestCase):
         )
         self.assertEqual(
             num2words('0', lang='am', to='currency', separator=' እና',
-                      cents=True, currency='ETB'), 'ዜሮ ብር እና ዜሮ ሳንቲም'
+                      cents=True, currency='ETB'), 'ዜሮ ብር'
         )
 
         self.assertEqual(

--- a/tests/test_en.py
+++ b/tests/test_en.py
@@ -86,7 +86,7 @@ class Num2WordsENTest(TestCase):
         self.assertEqual(
             num2words('0', lang='en', to='currency', separator=' and',
                       cents=False, currency='USD'),
-            "zero dollars and 00 cents"
+            "zero dollars"
         )
 
         self.assertEqual(

--- a/tests/test_en_ng.py
+++ b/tests/test_en_ng.py
@@ -51,7 +51,7 @@ class Num2WordsENNGTest(TestCase):
                 separator=separator,
                 kobo=False
             ),
-            "zero naira and 00 kobo"
+            "zero naira"
         )
 
         self.assertEqual(

--- a/tests/test_hu.py
+++ b/tests/test_hu.py
@@ -169,7 +169,7 @@ class Num2WordsHUTest(TestCase):
         self.assertEqual(
             num2words('0', lang='hu', to='currency', separator=' és',
                       cents=False, currency='HUF'),
-            "nulla forint és 00 fillér"
+            "nulla forint"
         )
 
         self.assertEqual(

--- a/tests/test_nl.py
+++ b/tests/test_nl.py
@@ -77,7 +77,7 @@ class Num2WordsNLTest(TestCase):
         self.assertEqual(
             num2words('0', lang='nl', to='currency', separator=' en',
                       cents=False, currency='EUR'),
-            "nul euro en 00 cent"
+            "nul euro"
         )
 
         self.assertEqual(
@@ -100,7 +100,7 @@ class Num2WordsNLTest(TestCase):
         self.assertEqual(
             num2words('0', lang='nl', to='currency', separator=' en',
                       cents=False, currency='USD'),
-            "nul dollar en 00 cent"
+            "nul dollar"
         )
 
         self.assertEqual(


### PR DESCRIPTION
## Fixes #554 by updating base.py

### Changes proposed in this pull request:

* Updated to_currency() in base.py to only display cents when input has a decimal (or explicit cents)
* e.g. 100 -> one hundred euro, 100.00 -> one hundred euro, zero cents
* Changed tests to align with this fix

### Status

- [X] READY
- [] HOLD
- [] WIP (Work-In-Progress)

### How to verify this change

* Run all tests in /tests
* Try "num2words 100 -t currency" and "num2words 100.00 -t currency" in the command line

### Additional notes

Not sure if this issue was a wanted bug fix or feature, but updated base.py to stop cents from being converted to words when not explicitly included in the number input (e.g. handling 100 vs 100.00 differently).

