### PR TITLE
IT: support Decimal class

### DIFF
--- a/num2words/lang_IT.py
+++ b/num2words/lang_IT.py
@@ -143,7 +143,7 @@ class Num2Word_IT(Num2Word_EU):
     def to_cardinal(self, number):
         if number < 0:
             string = Num2Word_IT.MINUS_PREFIX_WORD + self.to_cardinal(-number)
-        elif isinstance(number, float):
+        elif int(number) != number:
             string = self.float_to_words(number)
         elif number < 20:
             string = CARDINAL_WORDS[int(number)]

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -66,6 +66,10 @@ class Num2WordsITTest(TestCase):
 
     def test_float_to_cardinal(self):
         self.assertEqual(
+            num2words("3.1415", lang="it"),
+            "tre virgola uno quattro uno cinque"
+        )
+        self.assertEqual(
             num2words(3.1415, lang="it"), "tre virgola uno quattro uno cinque"
         )
         self.assertEqual(
@@ -264,10 +268,10 @@ class Num2WordsITTest(TestCase):
         )
 
     def test_with_floats(self):
-        self.assertAlmostEqual(
-            num2words(1.0, lang="it"), "uno virgola zero"
+        self.assertEqual(
+            num2words(1.0, lang="it"), "uno"
         )
-        self.assertAlmostEqual(
+        self.assertEqual(
             num2words(1.1, lang="it"), "uno virgola uno"
         )
 


### PR DESCRIPTION
### Changes proposed in this pull request:

* Italian language: detect non-integer cardinals regardless of whether they are `float` or `Decimal` (they will be the latter if a string is passed to `num2words()` rather than a float)
* Add test for this case

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Run tests

