### PR TITLE
Add support for Ligurian

### DIFF
--- a/num2words/__init__.py
+++ b/num2words/__init__.py
@@ -23,10 +23,11 @@ from . import (lang_AM, lang_AR, lang_AZ, lang_BE, lang_BN, lang_CA, lang_CE,
                lang_ES_GT, lang_ES_NI, lang_ES_VE, lang_FA, lang_FI, lang_FR,
                lang_FR_BE, lang_FR_CH, lang_FR_DZ, lang_HE, lang_HI, lang_HU,
                lang_HY, lang_ID, lang_IS, lang_IT, lang_JA, lang_KN, lang_KO,
-               lang_KZ, lang_LT, lang_LV, lang_MN, lang_NL, lang_NO, lang_PL,
-               lang_PT, lang_PT_BR, lang_RO, lang_RU, lang_SK, lang_SL,
-               lang_SR, lang_SV, lang_TE, lang_TET, lang_TG, lang_TH, lang_TR,
-               lang_UK, lang_VI, lang_ZH, lang_ZH_CN, lang_ZH_HK, lang_ZH_TW)
+               lang_KZ, lang_LIJ, lang_LT, lang_LV, lang_MN, lang_NL, lang_NO,
+               lang_PL, lang_PT, lang_PT_BR, lang_RO, lang_RU, lang_SK,
+               lang_SL, lang_SR, lang_SV, lang_TE, lang_TET, lang_TG, lang_TH,
+               lang_TR, lang_UK, lang_VI, lang_ZH, lang_ZH_CN, lang_ZH_HK,
+               lang_ZH_TW)
 
 CONVERTER_CLASSES = {
     'am': lang_AM.Num2Word_AM(),
@@ -67,6 +68,7 @@ CONVERTER_CLASSES = {
     'kn': lang_KN.Num2Word_KN(),
     'ko': lang_KO.Num2Word_KO(),
     'kz': lang_KZ.Num2Word_KZ(),
+    'lij': lang_LIJ.Num2Word_LIJ(),
     'lt': lang_LT.Num2Word_LT(),
     'lv': lang_LV.Num2Word_LV(),
     'mn': lang_MN.Num2Word_MN(),

--- a/num2words/lang_LIJ.py
+++ b/num2words/lang_LIJ.py
@@ -1,0 +1,317 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2003, Taro Ogawa.  All Rights Reserved.
+# Copyright (c) 2013, Savoir-faire Linux inc.  All Rights Reserved.
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301 USA
+
+from __future__ import unicode_literals
+
+from .currency import parse_currency_parts
+from .lang_EU import Num2Word_EU
+
+SMALL_CARDINALS = (
+    "zero un doî trei quattro çinque sëi sette eutto neuve dexe unze dozze"
+    " trezze quattòrze chinze sezze dïsette dixeutto dixineuve"
+).split()
+
+TENS = (
+    "zero dexe vinti trenta quaranta çinquanta sciuscianta settanta"
+    " ottanta novanta"
+).split()
+
+HUNDREDS = "zero çento duxento trexento".split()
+
+THOUSANDS = "zero mille doamia træmia".split()
+
+EXPONENTS = (
+    "mion miliardo bilion biliardo trilion triliardo quadrilion quadriliardo"
+    " quintilion quintiliardo"
+).split()
+
+SMALL_ORDINALS = (
+    "zero primmo segondo terso quarto quinto sesto setten otten noven dexen"
+    " unzen dozzen trezzen quattorzen chinzen sezzen dïsetten dixotten"
+    " dixinoven"
+).split()
+
+CENTS = ("citto", "citti")
+DOLLAR = (("dòllao", "dòllai"), CENTS)
+FRANC = (("franco", "franchi"), CENTS)
+CURRENCIES_FEM = {"GBP", "INR", "ISK", "ITL"}
+
+
+class Num2Word_LIJ(Num2Word_EU):
+    CURRENCY_FORMS = {
+        "AUD": DOLLAR,
+        "CAD": DOLLAR,
+        "CHF": FRANC,
+        "CNY": (("yuan", "yuan"), ("fen", "fen")),
+        "EUR": (("euro", "euro"), CENTS),
+        "FRF": FRANC,
+        "GBP": (("sterliña", "sterliñe"), ("penny", "pence")),
+        "HKD": DOLLAR,
+        "INR": (("rupia", "rupie"), ("paisa", "paise")),
+        "ITL": (("lia", "lie"), CENTS),
+        "JPY": (("yen", "yen"), ("sen", "sen")),
+        "SGD": DOLLAR,
+        "NZD": DOLLAR,
+        "USD": DOLLAR,
+    }
+    CURRENCY_ADJECTIVES = {
+        "AUD": ("australian", "australien"),
+        "CAD": ("canadeise", "canadeixi"),
+        "CHF": ("svissero", "svisseri"),
+        "FRF": ("franseise", "franseixi"),
+        "HKD": ("de Hong Kong", "de Hong Kong"),
+        "ITL": ("italiaña", "italiañe"),
+        "SGD": ("de Scingapô", "de Scingapô"),
+        "NZD": ("neozelandeise", "neozelandeixi"),
+        "USD": ("american", "americhen"),
+    }
+    MINUS_PREFIX_WORD = "meno "
+    FLOAT_INFIX_WORD = " virgola "
+
+    def __init__(self):
+        pass
+
+    def float_to_words(
+        self, float_number, gender="m", plural=False, ordinal=False
+    ):
+        if ordinal:
+            prefix = self.to_ordinal(int(float_number), gender, plural)
+        else:
+            prefix = self.to_cardinal(int(float_number), gender)
+        float_part = str(float_number).split(".")[1]
+        postfix = " ".join(
+            # Drops the trailing zero and comma
+            [self.to_cardinal(int(c)) for c in float_part]
+        )
+        return prefix + Num2Word_LIJ.FLOAT_INFIX_WORD + postfix
+
+    def small_to_cardinal(self, number, gender):
+        assert number < 20
+        string = SMALL_CARDINALS[number]
+        if gender == "f":
+            if number == 1:
+                string = string[:-1] + "ña"
+            if number == 2:
+                string = string[:-1] + "e"
+            if number == 3:
+                string = string[:-2] + "æ"
+        return string
+
+    def tens_to_cardinal(self, number, gender):
+        assert 20 <= number < 100
+        tens, units = number // 10, number % 10
+        string = TENS[tens]
+        # Bare tens
+        if units == 0:
+            return string
+        # Tens + units, with phonetic contractions
+        if tens != 2:
+            string = string[:-1] + "e"
+        if units in (1, 8):
+            string = string[:-1]
+        gender = gender if units != 1 else "m"
+        string += self.small_to_cardinal(units, gender)
+        return string
+
+    def hundreds_to_cardinal(self, number, gender):
+        assert 100 <= number < 1000
+        hundreds, remainder = number // 100, number % 100
+        if hundreds < len(HUNDREDS):
+            string = HUNDREDS[hundreds]
+            if 80 <= remainder <= 89:
+                string = string[:-1]
+        else:
+            string = self.small_to_cardinal(hundreds, gender="m")
+            string = string.replace("ë", "e")
+            # Phonetic adjustment
+            if 80 <= remainder <= 89:
+                string += "çent"
+            else:
+                string += "çento"
+        if not remainder:
+            return string
+        else:
+            gender = gender if remainder != 1 else "m"
+            return string + self.to_cardinal(remainder, gender)
+
+    def thousands_to_cardinal(self, number, gender):
+        assert 1000 <= number < 1000000
+        thousands, remainder = number // 1000, number % 1000
+        if thousands < len(THOUSANDS):
+            string = THOUSANDS[thousands]
+        else:
+            string = self.to_cardinal(thousands, gender="m")
+            # fossilised forms doa- and træ-
+            string = string.replace("doî", "doa")
+            string = string.replace("trei", "træ")
+            # no length markers on "sëi"
+            string = string.replace("ë", "e")
+            # no grave accent on "quattòrze" since it isn't the main stress
+            string = string.replace("ò", "o")
+            string += "mia"
+        if not remainder:
+            return string
+        else:
+            gender = gender if remainder != 1 else "m"
+            return string + self.to_cardinal(remainder, gender)
+
+    def big_number_to_cardinal(self, number, gender):
+        assert number >= 1000000
+        mils, remainder = number // 1000000, number % 1000000
+        rev_mils = str(mils)[::-1]
+        triplets = [
+            int(rev_mils[i:i + 3][::-1]) for i in range(0, len(rev_mils), 3)
+        ]
+        if len(triplets) > len(EXPONENTS):
+            raise NotImplementedError("The given number is too large.")
+        if remainder:
+            gender = gender if remainder != 1 else "m"
+            string = self.to_cardinal(remainder, gender)
+        else:
+            string = ""
+        for triplet, exponent in zip(triplets, EXPONENTS):
+            if triplet == 0:
+                prefix = ""
+            elif triplet == 1:
+                prefix = "un " + exponent
+            else:
+                prefix = self.to_cardinal(triplet) + " "
+                if exponent.endswith("n"):
+                    prefix += exponent[:-1] + "in"
+                else:
+                    prefix += exponent[:-1] + "i"
+            if prefix:
+                if string:
+                    if " e " in string:
+                        string = prefix + ", " + string
+                    else:
+                        string = prefix + " e " + string
+                else:
+                    string = prefix
+        return string
+
+    def to_cardinal(self, number, gender="m"):
+        if number < 0:
+            string = self.MINUS_PREFIX_WORD + self.to_cardinal(-number, gender)
+        elif int(number) != number:
+            string = self.float_to_words(number, gender)
+        elif number < 20:
+            string = self.small_to_cardinal(int(number), gender)
+        elif number < 100:
+            string = self.tens_to_cardinal(int(number), gender)
+        elif number < 1000:
+            string = self.hundreds_to_cardinal(int(number), gender)
+        elif number < 1000000:
+            string = self.thousands_to_cardinal(int(number), gender)
+        else:
+            string = self.big_number_to_cardinal(int(number), gender)
+        return string
+
+    def small_to_ordinal(self, number, gender, plural):
+        assert number < 20
+        string = SMALL_ORDINALS[int(number)]
+        if gender == "f" and string != "zero":
+            if string.endswith("o"):
+                string = string[:-1] + "a"
+            else:
+                string = string[:-1] + "ña"
+        if plural and string != "zero":
+            if string.endswith("o"):
+                string = string[:-1] + "i"
+            elif string.endswith("a"):
+                string = string[:-1] + "e"
+        return string
+
+    def big_to_odinal(self, number, gender, plural):
+        assert number >= 20
+        string = self.to_cardinal(number)
+        # Adjust diacritics and perform contractions
+        if string.endswith("ëi") or string.endswith("ei"):
+            string = string[:-2] + "ei"
+        elif string.endswith("quattòrze"):
+            string = string[:-4] + "orze"
+        elif string.endswith("î"):
+            string = string[:-1] + "i"
+        elif string[-1] in "oeai":
+            string = string[:-1]
+        string += "eximo"
+        # Additional phonetic adjustments
+        if string.endswith("mieximo"):
+            string = string[:-5] + "lleximo"
+        elif string.endswith("oeutteximo"):
+            string = string[:-10] + "otteximo"
+        elif string.endswith("eutteximo"):
+            string = string[:-9] + "otteximo"
+        elif string.endswith("neuveximo"):
+            string = string[:-8] + "oveximo"
+        # Gender/number adjustment
+        if gender == "f":
+            if plural:
+                string = string[:-1] + "e"
+            else:
+                string = string[:-1] + "a"
+        elif plural:
+            string = string[:-1] + "i"
+        return string
+
+    def to_ordinal(self, number, gender="m", plural=False):
+        if number < 0:
+            return self.MINUS_PREFIX_WORD + self.to_ordinal(
+                -number, gender, plural
+            )
+        elif number % 1 != 0:
+            return self.float_to_words(number, gender, plural, ordinal=True)
+        elif number < 20:
+            string = self.small_to_ordinal(number, gender, plural)
+        else:
+            string = self.big_to_odinal(number, gender, plural)
+        return string
+
+    def to_currency(
+        self, val, currency="EUR", cents=True, separator=" e", adjective=False
+    ):
+        left, right, is_negative = parse_currency_parts(val)
+
+        try:
+            cr1, cr2 = self.CURRENCY_FORMS[currency]
+
+        except KeyError:
+            raise NotImplementedError(
+                'Currency code "%s" not implemented for "%s"'
+                % (currency, self.__class__.__name__)
+            )
+
+        if adjective and currency in self.CURRENCY_ADJECTIVES:
+            adjs = self.CURRENCY_ADJECTIVES[currency]
+            cr1 = (
+                "%s %s" % (cr1[0], adjs[0]),
+                "%s %s" % (cr1[1], adjs[1]),
+            )
+
+        gender = "f" if currency in CURRENCIES_FEM else "m"
+        minus_str = "%s " % self.negword.strip() if is_negative else ""
+        money_str = self.to_cardinal(left, gender)
+        cents_str = self.to_cardinal(right) if cents else "%02d" % right
+
+        return "%s%s %s%s %s %s" % (
+            minus_str,
+            money_str,
+            self.pluralize(left, cr1),
+            separator,
+            cents_str,
+            self.pluralize(right, cr2),
+        )

--- a/tests/test_lij.py
+++ b/tests/test_lij.py
@@ -1,0 +1,415 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2003, Taro Ogawa.  All Rights Reserved.
+# Copyright (c) 2013, Savoir-faire Linux inc.  All Rights Reserved.
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301 USA
+
+from __future__ import unicode_literals
+
+from unittest import TestCase
+
+from num2words import num2words
+
+TEST_CASES_TO_CURRENCY_EUR = (
+    (1.00, "un euro e zero citti"),
+    (2.01, "doî euro e un citto"),
+    (8.10, "eutto euro e dexe citti"),
+    (12.26, "dozze euro e vintisëi citti"),
+    (21.29, "vintun euro e vintineuve citti"),
+    (81.25, "ottantun euro e vintiçinque citti"),
+    (100.00, "çento euro e zero citti"),
+)
+
+TEST_CASES_TO_CURRENCY_USD = (
+    (1.00, "un dòllao e zero citti"),
+    (2.01, "doî dòllai e un citto"),
+    (8.10, "eutto dòllai e dexe citti"),
+    (12.26, "dozze dòllai e vintisëi citti"),
+    (21.29, "vintun dòllai e vintineuve citti"),
+    (81.25, "ottantun dòllai e vintiçinque citti"),
+    (100.00, "çento dòllai e zero citti"),
+)
+
+TEST_CASES_TO_CURRENCY_GBP = (
+    (1.00, "uña sterliña e zero pence"),
+    (2.01, "doe sterliñe e un penny"),
+    (8.10, "eutto sterliñe e dexe pence"),
+    (12.26, "dozze sterliñe e vintisëi pence"),
+    (21.29, "vintun sterliñe e vintineuve pence"),
+    (81.25, "ottantun sterliñe e vintiçinque pence"),
+    (100.00, "çento sterliñe e zero pence"),
+)
+
+
+class Num2WordsLIJTest(TestCase):
+    maxDiff = None
+
+    def test_negative(self):
+        number = 648972145
+        pos_crd = num2words(+number, lang="lij")
+        neg_crd = num2words(-number, lang="lij")
+        pos_ord = num2words(+number, lang="lij", ordinal=True)
+        neg_ord = num2words(-number, lang="lij", ordinal=True)
+        self.assertEqual("meno " + pos_crd, neg_crd)
+        self.assertEqual("meno " + pos_ord, neg_ord)
+
+    def test_float_to_cardinal(self):
+        self.assertEqual(
+            num2words("3.1415", lang="lij"),
+            "trei virgola un quattro un çinque",
+        )
+        self.assertEqual(
+            num2words(3.1415, lang="lij"), "trei virgola un quattro un çinque"
+        )
+        self.assertEqual(
+            num2words(-5.15, lang="lij"), "meno çinque virgola un çinque"
+        )
+        self.assertEqual(
+            num2words(-0.15, lang="lij"), "meno zero virgola un çinque"
+        )
+
+    def test_float_to_ordinal(self):
+        self.assertEqual(
+            num2words(3.1415, lang="lij", ordinal=True),
+            "terso virgola un quattro un çinque",
+        )
+        self.assertEqual(
+            num2words(-5.15, lang="lij", ordinal=True),
+            "meno quinto virgola un çinque",
+        )
+        self.assertEqual(
+            num2words(-0.15, lang="lij", ordinal=True),
+            "meno zero virgola un çinque",
+        )
+
+    def test_0(self):
+        self.assertEqual(num2words(0, lang="lij"), "zero")
+        self.assertEqual(num2words(0, lang="lij", ordinal=True), "zero")
+
+    def test_1_to_10(self):
+        self.assertEqual(num2words(1, lang="lij"), "un")
+        self.assertEqual(num2words(1, lang="lij", gender="f"), "uña")
+        self.assertEqual(num2words(2, lang="lij"), "doî")
+        self.assertEqual(num2words(2, lang="lij", gender="f"), "doe")
+        self.assertEqual(num2words(3, lang="lij"), "trei")
+        self.assertEqual(num2words(3, lang="lij", gender="f"), "træ")
+        self.assertEqual(num2words(7, lang="lij"), "sette")
+        self.assertEqual(num2words(7, lang="lij", gender="f"), "sette")
+        self.assertEqual(num2words(10, lang="lij"), "dexe")
+
+    def test_11_to_19(self):
+        self.assertEqual(num2words(11, lang="lij"), "unze")
+        self.assertEqual(num2words(13, lang="lij"), "trezze")
+        self.assertEqual(num2words(15, lang="lij"), "chinze")
+        self.assertEqual(num2words(16, lang="lij"), "sezze")
+        self.assertEqual(num2words(19, lang="lij"), "dixineuve")
+
+    def test_20_to_99(self):
+        self.assertEqual(num2words(20, lang="lij"), "vinti")
+        self.assertEqual(num2words(21, lang="lij"), "vintun")
+        self.assertEqual(num2words(21, lang="lij", gender="f"), "vintun")
+        self.assertEqual(num2words(23, lang="lij"), "vintitrei")
+        self.assertEqual(num2words(23, lang="lij", gender="f"), "vintitræ")
+        self.assertEqual(num2words(28, lang="lij"), "vinteutto")
+        self.assertEqual(num2words(31, lang="lij"), "trentun")
+        self.assertEqual(num2words(40, lang="lij"), "quaranta")
+        self.assertEqual(num2words(66, lang="lij"), "sciusciantesëi")
+        self.assertEqual(num2words(92, lang="lij"), "novantedoî")
+        self.assertEqual(num2words(92, lang="lij", gender="f"), "novantedoe")
+
+    def test_100_to_999(self):
+        self.assertEqual(num2words(100, lang="lij"), "çento")
+        self.assertEqual(num2words(111, lang="lij"), "çentounze")
+        self.assertEqual(num2words(150, lang="lij"), "çentoçinquanta")
+        self.assertEqual(num2words(196, lang="lij"), "çentonovantesëi")
+        self.assertEqual(num2words(200, lang="lij"), "duxento")
+        self.assertEqual(num2words(210, lang="lij"), "duxentodexe")
+        self.assertEqual(num2words(701, lang="lij"), "setteçentoun")
+        self.assertEqual(
+            num2words(701, lang="lij", gender="f"), "setteçentoun"
+        )
+        self.assertEqual(num2words(882, lang="lij"), "euttoçentottantedoî")
+        self.assertEqual(
+            num2words(882, lang="lij", gender="f"), "euttoçentottantedoe"
+        )
+
+    def test_1000_to_9999(self):
+        self.assertEqual(num2words(1000, lang="lij"), "mille")
+        self.assertEqual(num2words(1001, lang="lij"), "milleun")
+        self.assertEqual(num2words(1001, lang="lij", gender="f"), "milleun")
+        self.assertEqual(num2words(1500, lang="lij"), "milleçinqueçento")
+        self.assertEqual(
+            num2words(7378, lang="lij"), "settemiatrexentosettanteutto"
+        )
+        self.assertEqual(num2words(2000, lang="lij"), "doamia")
+        self.assertEqual(num2words(2100, lang="lij"), "doamiaçento")
+        self.assertEqual(
+            num2words(6870, lang="lij"), "seimiaeuttoçentosettanta"
+        )
+        self.assertEqual(num2words(10000, lang="lij"), "dexemia")
+        self.assertEqual(
+            num2words(98765, lang="lij"),
+            "novanteuttomiasetteçentosciuscianteçinque",
+        )
+        self.assertEqual(num2words(100000, lang="lij"), "çentomia")
+        self.assertEqual(
+            num2words(523456, lang="lij"),
+            "çinqueçentovintitræmiaquattroçentoçinquantesëi",
+        )
+
+    def test_big(self):
+        self.assertEqual(num2words(1000000, lang="lij"), "un mion")
+        self.assertEqual(num2words(1000007, lang="lij"), "un mion e sette")
+        self.assertEqual(num2words(1000001, lang="lij"), "un mion e un")
+        self.assertEqual(
+            num2words(1000001, lang="lij", gender="f"), "un mion e un"
+        )
+        self.assertEqual(
+            num2words(1200000, lang="lij"), "un mion e duxentomia"
+        )
+        self.assertEqual(num2words(3000000, lang="lij"), "trei mioin")
+        self.assertEqual(num2words(3000005, lang="lij"), "trei mioin e çinque")
+        self.assertEqual(
+            num2words(3800000, lang="lij"), "trei mioin e euttoçentomia"
+        )
+        self.assertEqual(num2words(1000000000, lang="lij"), "un miliardo")
+        self.assertEqual(
+            num2words(1000000017, lang="lij"), "un miliardo e dïsette"
+        )
+        self.assertEqual(num2words(2000000000, lang="lij"), "doî miliardi")
+        self.assertEqual(
+            num2words(2000001000, lang="lij"), "doî miliardi e mille"
+        )
+        self.assertEqual(
+            num2words(1234567890, lang="lij"),
+            "un miliardo, duxentotrentequattro mioin e "
+            "çinqueçentosciusciantesettemiaeuttoçentonovanta",
+        )
+        self.assertEqual(num2words(1000000000000, lang="lij"), "un bilion")
+        self.assertEqual(
+            num2words(123456789012345678901234567890, lang="lij"),
+            "çentovintitrei quadriliardi, quattroçentoçinquantesëi "
+            "quadrilioin, setteçentottanteneuve triliardi, dozze trilioin, "
+            "trexentoquaranteçinque biliardi, seiçentosettanteutto bilioin, "
+            "neuveçentoun miliardi, duxentotrentequattro mioin e "
+            "çinqueçentosciusciantesettemiaeuttoçentonovanta",
+        )
+
+    def test_too_big(self):
+        with self.assertRaises(NotImplementedError):
+            num2words(10**39, lang="lij")
+
+    def test_nth_1_to_99(self):
+        self.assertEqual(num2words(1, lang="lij", ordinal=True), "primmo")
+        self.assertEqual(
+            num2words(1, lang="lij", ordinal=True, plural=True), "primmi"
+        )
+        self.assertEqual(
+            num2words(1, lang="lij", ordinal=True, gender="f"), "primma"
+        )
+        self.assertEqual(num2words(8, lang="lij", ordinal=True), "otten")
+        self.assertEqual(
+            num2words(8, lang="lij", ordinal=True, plural=True), "otten"
+        )
+        self.assertEqual(
+            num2words(8, lang="lij", ordinal=True, gender="f"), "otteña"
+        )
+        self.assertEqual(
+            num2words(
+                8,
+                lang="lij",
+                ordinal=True,
+                gender="f",
+                plural=True,
+            ),
+            "otteñe",
+        )
+        self.assertEqual(
+            num2words(21, lang="lij", ordinal=True), "vintuneximo"
+        )
+        self.assertEqual(
+            num2words(23, lang="lij", ordinal=True), "vintitreieximo"
+        )
+        self.assertEqual(
+            num2words(47, lang="lij", ordinal=True), "quarantesetteximo"
+        )
+        self.assertEqual(
+            num2words(99, lang="lij", ordinal=True), "novantenoveximo"
+        )
+
+    def test_nth_100_to_999(self):
+        self.assertEqual(num2words(100, lang="lij", ordinal=True), "çenteximo")
+        self.assertEqual(
+            num2words(100, lang="lij", ordinal=True, gender="f"), "çentexima"
+        )
+        self.assertEqual(
+            num2words(100, lang="lij", ordinal=True, plural=True), "çenteximi"
+        )
+        self.assertEqual(
+            num2words(100, lang="lij", ordinal=True, gender="f", plural=True),
+            "çentexime",
+        )
+        self.assertEqual(
+            num2words(101, lang="lij", ordinal=True), "çentouneximo"
+        )
+        self.assertEqual(
+            num2words(188, lang="lij", ordinal=True), "çentottantotteximo"
+        )
+        self.assertEqual(
+            num2words(112, lang="lij", ordinal=True), "çentodozzeximo"
+        )
+        self.assertEqual(
+            num2words(120, lang="lij", ordinal=True), "çentovinteximo"
+        )
+        self.assertEqual(
+            num2words(121, lang="lij", ordinal=True), "çentovintuneximo"
+        )
+        self.assertEqual(
+            num2words(316, lang="lij", ordinal=True), "trexentosezzeximo"
+        )
+        self.assertEqual(
+            num2words(700, lang="lij", ordinal=True), "setteçenteximo"
+        )
+        self.assertEqual(
+            num2words(803, lang="lij", ordinal=True), "euttoçentotreieximo"
+        )
+        self.assertEqual(
+            num2words(923, lang="lij", ordinal=True),
+            "neuveçentovintitreieximo",
+        )
+
+    def test_nth_1000_to_999999(self):
+        self.assertEqual(
+            num2words(1000, lang="lij", ordinal=True), "milleximo"
+        )
+        self.assertEqual(
+            num2words(1001, lang="lij", ordinal=True), "milleuneximo"
+        )
+        self.assertEqual(
+            num2words(1003, lang="lij", ordinal=True), "milletreieximo"
+        )
+        self.assertEqual(
+            num2words(1200, lang="lij", ordinal=True), "milleduxenteximo"
+        )
+        self.assertEqual(
+            num2words(1800, lang="lij", ordinal=True, gender="f", plural=True),
+            "milleeuttoçentexime",
+        )
+        self.assertEqual(
+            num2words(8640, lang="lij", ordinal=True),
+            "euttomiaseiçentoquaranteximo",
+        )
+        self.assertEqual(
+            num2words(14000, lang="lij", ordinal=True), "quattorzemilleximo"
+        )
+        self.assertEqual(
+            num2words(123456, lang="lij", ordinal=True),
+            "çentovintitræmiaquattroçentoçinquanteseieximo",
+        )
+        self.assertEqual(
+            num2words(987654, lang="lij", ordinal=True),
+            "neuveçentottantesettemiaseiçentoçinquantequattreximo",
+        )
+
+    def test_nth_big(self):
+        self.assertEqual(
+            num2words(1000000001, lang="lij", ordinal=True),
+            "un miliardo e uneximo",
+        )
+        self.assertEqual(
+            num2words(1000000001, lang="lij", ordinal=True, gender="f"),
+            "un miliardo e unexima",
+        )
+        self.assertEqual(
+            num2words(
+                123456789012345678901234567890, lang="lij", ordinal=True
+            ),
+            "çentovintitrei quadriliardi, quattroçentoçinquantesëi "
+            "quadrilioin, setteçentottanteneuve triliardi, dozze trilioin, "
+            "trexentoquaranteçinque biliardi, seiçentosettanteutto bilioin, "
+            "neuveçentoun miliardi, duxentotrentequattro mioin e "
+            "çinqueçentosciusciantesettemiaeuttoçentonovanteximo",
+        )
+
+    def test_with_floats(self):
+        self.assertEqual(num2words(1.0, lang="lij"), "un")
+        self.assertEqual(num2words(1.1, lang="lij"), "un virgola un")
+
+    def test_with_strings(self):
+        for i in range(2002):
+            # Just make sure it doesn't raise an exception
+            num2words(str(i), lang="lij", to="cardinal")
+            num2words(str(i), lang="lij", to="ordinal")
+        self.assertEqual(num2words("1", lang="lij", to="ordinal"), "primmo")
+        self.assertEqual(
+            num2words("100", lang="lij", to="ordinal"), "çenteximo"
+        )
+        self.assertEqual(
+            num2words("1000", lang="lij", to="ordinal"), "milleximo"
+        )
+        self.assertEqual(
+            num2words(
+                "1234567890123456789012345678", lang="lij", to="ordinal"
+            ),
+            "un quadriliardo, duxentotrentequattro quadrilioin, "
+            "çinqueçentosciusciantesette triliardi, euttoçentonovanta "
+            "trilioin, çentovintitrei biliardi, quattroçentoçinquantesëi "
+            "bilioin, setteçentottanteneuve miliardi, dozze mioin e "
+            "trexentoquaranteçinquemiaseiçentosettantotteximo",
+        )
+
+    def test_currency_eur(self):
+        for test in TEST_CASES_TO_CURRENCY_EUR:
+            self.assertEqual(
+                num2words(test[0], lang="lij", to="currency", currency="EUR"),
+                test[1],
+            )
+
+    def test_currency_usd(self):
+        for test in TEST_CASES_TO_CURRENCY_USD:
+            self.assertEqual(
+                num2words(test[0], lang="lij", to="currency", currency="USD"),
+                test[1],
+            )
+
+    def test_currency_gbp(self):
+        for test in TEST_CASES_TO_CURRENCY_GBP:
+            self.assertEqual(
+                num2words(test[0], lang="lij", to="currency", currency="GBP"),
+                test[1],
+            )
+
+    def test_currency_adjs(self):
+        currencies = "USD HKD CHF FRF".split()
+        names = [
+            "doî dòllai americhen",
+            "doî dòllai de Hong Kong",
+            "doî franchi svisseri",
+            "doî franchi franseixi",
+        ]
+        for currency, name in zip(currencies, names):
+            self.assertEqual(
+                num2words(
+                    2.01,
+                    lang="lij",
+                    to="currency",
+                    currency=currency,
+                    adjective=True,
+                ),
+                name + " e un citto",
+            )
+
+    def test_unk_currency(self):
+        with self.assertRaises(NotImplementedError):
+            num2words(1, lang="lij", to="currency", currency="XTS")


### PR DESCRIPTION
## Adds support for the Ligurian language

### Changes proposed in this pull request:

* Added support for cardinal numbers and currencies, taking inspiration from French and Italian implementations.
* Added support for ordinals, including feminine form (`gender="f"`) and plural (`plural=True`).
* Checked PEP8 compliance.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

I've added extensive tests in `tests/test_lij.py` and verified they pass.
