### PR TITLE
Fix negword before zero with floats

### DIFF
--- a/num2words/base.py
+++ b/num2words/base.py
@@ -148,6 +148,9 @@ class Num2Word_Base(object):
         post = '0' * (self.precision - len(post)) + post
 
         out = [self.to_cardinal(pre)]
+        if value < 0 and pre == 0:
+            out = [self.negword.strip()] + out
+
         if self.precision:
             out.append(self.title(self.pointword))
 

--- a/tests/test_en.py
+++ b/tests/test_en.py
@@ -62,6 +62,8 @@ class Num2WordsENTest(TestCase):
         self.assertEqual(num2words(73, lang='en', to='ordinal_num'), '73rd')
 
     def test_cardinal_for_float_number(self):
+        self.assertEqual(num2words(0.12), "zero point one two")
+        self.assertEqual(num2words(-0.12), "minus zero point one two")
         # issue 24
         self.assertEqual(num2words(12.5), "twelve point five")
         self.assertEqual(num2words(12.51), "twelve point five one")


### PR DESCRIPTION
## Fix negword before zero with floats # by updating base.py

### Changes proposed in this pull request:

Current behaviour
> num2words(-0.12, lang="en")
'zero point one two'

Expected behaviour
> num2words(-0.12, lang="en")
'minus zero point one two'


### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

