### PR TITLE
Uzbek language added!

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,6 +132,7 @@ Besides the numerical argument, there are two main optional arguments, ``to:`` a
 * ``tr`` (Turkish)
 * ``th`` (Thai)
 * ``uk`` (Ukrainian)
+* ``uz`` (Uzbek)
 * ``vi`` (Vietnamese)
 * ``zh`` (Chinese - Traditional)
 * ``zh_CN`` (Chinese - Simplified / Mainland China)

--- a/num2words/__init__.py
+++ b/num2words/__init__.py
@@ -25,7 +25,7 @@ from . import (lang_AM, lang_AR, lang_AZ, lang_BE, lang_BN, lang_CA, lang_CE,
                lang_ID, lang_IS, lang_IT, lang_JA, lang_KN, lang_KO, lang_KZ,
                lang_LT, lang_LV, lang_MN, lang_NL, lang_NO, lang_PL, lang_PT,
                lang_PT_BR, lang_RO, lang_RU, lang_SK, lang_SL, lang_SR,
-               lang_SV, lang_TE, lang_TET, lang_TG, lang_TH, lang_TR, lang_UK,
+               lang_SV, lang_TE, lang_TET, lang_TG, lang_TH, lang_TR, lang_UK, lang_UZ,
                lang_VI, lang_ZH, lang_ZH_CN, lang_ZH_HK, lang_ZH_TW)
 
 CONVERTER_CLASSES = {
@@ -82,6 +82,7 @@ CONVERTER_CLASSES = {
     'tr': lang_TR.Num2Word_TR(),
     'nl': lang_NL.Num2Word_NL(),
     'uk': lang_UK.Num2Word_UK(),
+    'uz': lang_UZ.Num2Word_UZ(),
     'te': lang_TE.Num2Word_TE(),
     'tet': lang_TET.Num2Word_TET(),
     'hu': lang_HU.Num2Word_HU(),

--- a/num2words/lang_UZ.py
+++ b/num2words/lang_UZ.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2003, Taro Ogawa.  All Rights Reserved.
+# Copyright (c) 2013, Savoir-faire Linux inc.  All Rights Reserved.
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301 USA
+
+from __future__ import unicode_literals
+
+from .base import Num2Word_Base
+from .utils import get_digits, splitbyx
+
+ZERO = 'nol'
+
+ONES = {
+    1: 'bir',
+    2: 'ikki',
+    3: 'uch',
+    4: 'toʻrt',
+    5: 'besh',
+    6: 'olti',
+    7: 'yetti',
+    8: 'sakkiz',
+    9: 'toʻqqiz',
+}
+
+TEN = 'oʻn'
+
+TWENTIES = {
+    2: 'yigirma',
+    3: 'oʻttiz',
+    4: 'qirq',
+    5: 'ellik',
+    6: 'oltmish',
+    7: 'yetmish',
+    8: 'sakson',
+    9: 'toʻqson',
+}
+HUNDRED = 'bir yuz'
+
+THOUSANDS = {
+    1: 'ming',
+    2: 'million',
+    3: 'milliard',
+    4: 'trillion',
+    5: 'kvadrillion',
+    6: 'kvintillion',
+    7: 'sextillion',
+    8: 'septillion',
+    9: 'oktilion',
+    10: 'nonillion',
+}
+
+
+class Num2Word_UZ(Num2Word_Base):
+    CURRENCY_FORMS = {
+        'USD': ('dollar', 'sent'),
+        'UZS': ('soʻm', 'tiyin'),
+        'RUB': ('rubl', 'kopek'),
+        'EUR': ('yevro', 'sent'),
+        'GBP': ('funt', 'pens'),
+    }
+
+    def setup(self):
+        self.negword = "minus"
+        self.pointword = "butun"
+
+    def to_cardinal(self, number):
+        n = str(number).replace(',', '.')
+        if '.' in n:
+            left, right = n.split('.')
+            leading_zero_count = len(right) - len(right.lstrip('0'))
+            return u'%s %s %s' % (
+                self._int2word(int(left)),
+                self.pointword,
+                (ZERO + ' ') * leading_zero_count + self._int2word(int(right))
+            )
+        else:
+            return self._int2word(int(n))
+
+    def pluralize(self, n, form):
+        return form
+
+    def _cents_verbose(self, number, currency):
+        return self._int2word(number, currency == 'UZS')
+
+    def _int2word(self, n, feminine=False):
+        if n < 0:
+            return ' '.join([self.negword, self._int2word(abs(n))])
+        if n == 0:
+            return ZERO
+
+        words = []
+        chunks = list(splitbyx(str(n), 3))
+        i = len(chunks)
+        for x in chunks:
+            i -= 1
+            if x == 0:
+                continue
+
+            n1, n2, n3 = get_digits(x)
+
+            if n3 > 0:
+                if n3 == 1:
+                    words.append(HUNDRED)
+                if n3 > 1:
+                    words.append(ONES[n3] + ' yuz')
+
+            if n2 == 1:
+                words.append(TEN)
+            elif n2 > 1:
+                words.append(TWENTIES[n2])
+
+            if n1 > 0:
+                words.append(ONES[n1])
+
+            if i > 0:
+                words.append(THOUSANDS[i])
+
+        return ' '.join(words)
+
+    def to_ordinal(self, number):
+        raise NotImplementedError()

--- a/tests/test_uz.py
+++ b/tests/test_uz.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2003, Taro Ogawa.  All Rights Reserved.
+# Copyright (c) 2013, Savoir-faire Linux inc.  All Rights Reserved.
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301 USA
+
+from __future__ import unicode_literals
+
+from unittest import TestCase
+
+from num2words import num2words
+
+TEST_CASES_CARDINAL = (
+    (1, "bir"),
+    (2, "ikki"),
+    (3, "uch"),
+    (4, "toʻrt"),
+    (5, "besh"),
+    (6, "olti"),
+    (7, "yetti"),
+    (8, "sakkiz"),
+    (9, "toʻqqiz"),
+    (10, "oʻn"),
+    (10.01, "oʻn butun nol bir"),
+    (11, "oʻn bir"),
+    (12, "oʻn ikki"),
+    (12.50, "oʻn ikki butun besh"),
+    (13, "oʻn uch"),
+    (14, "oʻn toʻrt"),
+    (14.13, "oʻn toʻrt butun oʻn uch"),
+    (15, "oʻn besh"),
+    (16, "oʻn olti"),
+    (17, "oʻn yetti"),
+    (17.31, "oʻn yetti butun oʻttiz bir"),
+    (18, "oʻn sakkiz"),
+    (19, "oʻn toʻqqiz"),
+    (20, "yigirma"),
+    (21, "yigirma bir"),
+    (21.20, "yigirma bir butun ikki"),
+    (30, "oʻttiz"),
+    (32, "oʻttiz ikki"),
+    (40, "qirq"),
+    (43, "qirq uch"),
+    (43.007, "qirq uch butun nol nol yetti"),
+    (50, "ellik"),
+    (54, "ellik toʻrt"),
+    (60, "oltmish"),
+    (60.059, "oltmish butun nol ellik toʻqqiz"),
+    (65, "oltmish besh"),
+    (70, "yetmish"),
+    (76, "yetmish olti"),
+    (80, "sakson"),
+    (87, "sakson yetti"),
+    (90, "toʻqson"),
+    (98, "toʻqson sakkiz"),
+    (99, "toʻqson toʻqqiz"),
+    (100, "bir yuz"),
+    (101, "bir yuz bir"),
+    (199, "bir yuz toʻqson toʻqqiz"),
+    (200, "ikki yuz"),
+    (203, "ikki yuz uch"),
+    (300, "uch yuz"),
+    (356, "uch yuz ellik olti"),
+    (400, "toʻrt yuz"),
+    (434, "toʻrt yuz oʻttiz toʻrt"),
+    (500, "besh yuz"),
+    (578, "besh yuz yetmish sakkiz"),
+    (600, "olti yuz"),
+    (689, "olti yuz sakson toʻqqiz"),
+    (700, "yettiyuz"),
+    (729, "yetti yuz yigirma toʻqqiz"),
+    (800, "sakkiz yuz"),
+    (894, "sakkiz yuz toʻqson toʻrt"),
+    (900, "toʻqqiz yuz"),
+    (999, "toʻqqiz yuz toʻqson toʻqqiz"),
+    (1000, "bir ming"),
+    (1001, "bir ming bir"),
+    (2012, "ikki ming oʻn ikki"),
+    (2025, "ikki ming yigirma besh"),
+    (1234, "bir ming ikki yuz oʻttiz toʻrt"),
+    (12345.65, "oʻn ikki ming uch yuz qirq besh butun oltmish besh"),
+    (-260000, "minus ikki yuz oltmish ming"),
+    (777777, "yetti yuz yetmish yetti ming yetti yuz yetmish yetti"),
+    (999999, "toʻqqiz yuz toʻqson toʻqqiz ming toʻqqiz yuz toʻqson toʻqqiz"),
+    (1000000, "bir million"),
+    (1000000000, "bir milliard"),
+    (1234567890, "bir milliard ikki yuz oʻttiz toʻrt million besh yuz oltmish yetti ming sakkiz yuz toʻqson"),
+    (1000000000000000, "bir kvadrillion"),
+    (1000000000000000000, "bir kvintillion"),
+    (1000000000000000000000, "bir sextillion"),
+    (1000000000000000000000000, "bir septillion"),
+    (1000000000000000000000000000, "bir oktilion"),
+    (1000000000000000000000000000000, "bir nonillion"),
+    (215461407892039002157189883901676,
+     "ikki yuz oʻn besh nonillion toʻrt yuz oltmish bir oktilion toʻrt yuz "
+     "yetti septillion sakkiz yuz toʻqson ikki sextillion oʻttiz toʻqqiz kvintillion "
+     "ikki kvadrillion bir yuz ellik yetti trillion bir yuz sakson toʻqqiz milliard sakkiz "
+     "yuz sakson uch million toʻqqiz yuz bir ming olti yuz yetmish olti"),
+    (719094234693663034822824384220291,
+     "yetti yuz oʻn toʻqqiz nonillion toʻqson toʻrt oktilion ikki yuz oʻttiz toʻrt septillion "
+     "olti yuz toʻqson uch sextillion olti yuz oltmish uch kvintillion oʻttiz toʻrt kvadrillion "
+     "sakkiz yuz yigirma ikki trillion sakkiz yuz yigirma toʻrt milliard uch yuz sakson toʻrt "
+     "million ikki yuz yigirma ming ikki yuz toʻqson bir"),
+)
+TEST_CASES_TO_CURRENCY_UZS = (
+    (0.00, "nol soʻm, nol tiyin"),
+    (1.00, "bir soʻm, nol tiyin"),
+    (2.00, "ikki soʻm, nol tiyin"),
+    (5.05, "besh soʻm, nol besh tiyin"),
+    (7.77, "yetti soʻm, yetmish yetti tiyin"),
+    (10.01, "oʻn soʻm, bir tiyin"),
+    (100.0, "bir yuz soʻm, nol tiyin"),
+    (1000.0, "ming soʻm, nol tiyin"),
+    (10000.99, "oʻn ming soʻm, toʻqson toʻqqiz tiyin"),
+    (200_000.0, "ikki yuz ming soʻm, nol tiyin"),
+    (10_000_000.0, "oʻn million soʻm, nol tiyin"),
+    (10222.0, "oʻn ming ikki yuz yigirma ikki soʻm, nol tiyin"),
+)


### PR DESCRIPTION
### Changes proposed in this pull request:
Hi, I've added Uzbek language support. Could you please help trigger the CI tests or let me know if I need to adjust anything? Thank you! 
Because the library did not have Uzbek language before. There are no changes here. Everything is new, new changes will be added in the future! Coming soon

For now, it can only display numbers in text format with high accuracy

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

```python
from num2words import num2words
print(num2words(42, lang='uz'))  # qirq ikki
print(num2words(5.05, lang='uz', to='currency', currency='UZS'))  # besh soʻm, nol besh tiyin
```

### Additional notes
**I decided to add this language because the number of Uzbeks in the world is now approaching 50 million. It clearly reads the numbers you enter in pure Uzbek.**

