### PR TITLE
Fix IndexError converting 0 to ordinal in Polish and Ukrainian

### DIFF
--- a/num2words/lang_PL.py
+++ b/num2words/lang_PL.py
@@ -221,6 +221,10 @@ class Num2Word_PL(Num2Word_Base):
     def to_ordinal(self, number):
         if number % 1 != 0:
             raise NotImplementedError()
+        if number == 0:
+            # splitbyx("0") yields a single zero fragment; the loop below would
+            # pop it and then index an empty list, so handle zero explicitly.
+            return "zerowy"
         words = []
         fragments = list(splitbyx(str(number), 3))
         level = 0

--- a/num2words/lang_UK.py
+++ b/num2words/lang_UK.py
@@ -1043,6 +1043,11 @@ class Num2Word_UK(Num2Word_Base):
     def to_ordinal(self, number):
         self.verify_ordinal(number)
 
+        if number == 0:
+            # splitbyx("0") yields a single zero fragment; the loop below would
+            # pop it and then index an empty list, so handle zero explicitly.
+            return "нульовий"
+
         words = []
         fragments = list(splitbyx(str(number), 3))
         level = 0

--- a/tests/test_pl.py
+++ b/tests/test_pl.py
@@ -93,6 +93,7 @@ class Num2WordsPLTest(TestCase):
         )
 
     def test_to_ordinal(self):
+        self.assertEqual(num2words(0, lang='pl', to='ordinal'), "zerowy")
         self.assertEqual(num2words(100, lang='pl', to='ordinal'), "setny")
         self.assertEqual(
             num2words(101, lang='pl', to='ordinal'), "sto pierwszy")

--- a/tests/test_uk.py
+++ b/tests/test_uk.py
@@ -700,6 +700,7 @@ TEST_CASES_CARDINAL_LOCATIVE = (
 )
 
 TEST_CASES_ORDINAL = (
+    (0, "нульовий"),
     (1, "перший"),
     (2, "другий"),
     (3, "третій"),


### PR DESCRIPTION
`num2words(0, lang='pl', to='ordinal')` and `lang='uk'` raise `IndexError: list index out of range`.

`to_ordinal` splits the number into 3-digit fragments and pops trailing all-zero fragments; for `0` that empties the list and the next `fragments[-1]` raises. Both languages return correct ordinals for every other integer (1 -> pierwszy/перший, 100 -> setny/сотий), and en/ru/de/fr already return a zero ordinal, so return the zero ordinal (`zerowy` / `нульовий`) which matches each module's masculine-nominative convention.

Same bug class as #661 (Mongolian); this covers Polish and Ukrainian. Adds a regression case to each language's ordinal test.