### PR TITLE
Fix ValueError converting negative integers to cardinal in pl, cs, sk

### DIFF
--- a/num2words/lang_CS.py
+++ b/num2words/lang_CS.py
@@ -100,6 +100,8 @@ class Num2Word_CS(Num2Word_Base):
 
     def to_cardinal(self, number):
         n = str(number).replace(',', '.')
+        if n.startswith('-'):
+            return '%s %s' % (self.negword.strip(), self.to_cardinal(n[1:]))
         if '.' in n:
             left, right = n.split('.')
             leading_zero_count = len(right) - len(right.lstrip('0'))

--- a/num2words/lang_PL.py
+++ b/num2words/lang_PL.py
@@ -175,6 +175,8 @@ class Num2Word_PL(Num2Word_Base):
 
     def to_cardinal(self, number):
         n = str(number).replace(',', '.')
+        if n.startswith('-'):
+            return '%s %s' % (self.negword.strip(), self.to_cardinal(n[1:]))
         if '.' in n:
             left, right = n.split('.')
             leading_zero_count = len(right) - len(right.lstrip('0'))

--- a/num2words/lang_SK.py
+++ b/num2words/lang_SK.py
@@ -96,6 +96,8 @@ class Num2Word_SK(Num2Word_Base):
 
     def to_cardinal(self, number):
         n = str(number).replace(',', '.')
+        if n.startswith('-'):
+            return '%s %s' % (self.negword.strip(), self.to_cardinal(n[1:]))
         if '.' in n:
             left, right = n.split('.')
             leading_zero_count = len(right) - len(right.lstrip('0'))

--- a/tests/test_cs.py
+++ b/tests/test_cs.py
@@ -72,6 +72,14 @@ class Num2WordsCSTest(TestCase):
             "tisíc dvěstě devadesát jedna"
         )
 
+    def test_cardinal_negative(self):
+        self.assertEqual(num2words(-1, lang='cs'), "mínus jedna")
+        self.assertEqual(num2words(-5, lang='cs'), "mínus pět")
+        self.assertEqual(num2words(-123, lang='cs'), "mínus sto dvacet tři")
+        self.assertEqual(num2words(-1000000, lang='cs'), "mínus milion")
+        self.assertEqual(num2words(-5.5, lang='cs'), "mínus pět celá pět")
+        self.assertEqual(num2words(-0.5, lang='cs'), "mínus nula celá pět")
+
     def test_to_ordinal(self):
         # @TODO: implement to_ordinal
         with self.assertRaises(NotImplementedError):

--- a/tests/test_pl.py
+++ b/tests/test_pl.py
@@ -92,6 +92,17 @@ class Num2WordsPLTest(TestCase):
             "sześć kwintyliardów sto dwa kwintyliony tysiąc siedem"
         )
 
+    def test_cardinal_negative(self):
+        self.assertEqual(num2words(-1, lang='pl'), "minus jeden")
+        self.assertEqual(num2words(-5, lang='pl'), "minus pięć")
+        self.assertEqual(
+            num2words(-123, lang='pl'), "minus sto dwadzieścia trzy")
+        self.assertEqual(num2words(-1000000, lang='pl'), "minus milion")
+        self.assertEqual(
+            num2words(-5.5, lang='pl'), "minus pięć przecinek pięć")
+        self.assertEqual(
+            num2words(-0.5, lang='pl'), "minus zero przecinek pięć")
+
     def test_to_ordinal(self):
         self.assertEqual(num2words(100, lang='pl', to='ordinal'), "setny")
         self.assertEqual(

--- a/tests/test_sk.py
+++ b/tests/test_sk.py
@@ -72,6 +72,14 @@ class Num2WordsSKTest(TestCase):
             "dvestodvadsaťtisícdvestodeväťdesiatjeden"
         )
 
+    def test_cardinal_negative(self):
+        self.assertEqual(num2words(-1, lang='sk'), "mínus jeden")
+        self.assertEqual(num2words(-5, lang='sk'), "mínus päť")
+        self.assertEqual(num2words(-123, lang='sk'), "mínus stodvadsaťtri")
+        self.assertEqual(num2words(-1000000, lang='sk'), "mínus milión")
+        self.assertEqual(num2words(-5.5, lang='sk'), "mínus päť celých päť")
+        self.assertEqual(num2words(-0.5, lang='sk'), "mínus nula celých päť")
+
     def test_to_ordinal(self):
         # @TODO: implement to_ordinal
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
`Num2Word_PL/CS/SK.to_cardinal` passes the value straight to `splitbyx` without stripping the sign, so any negative integer raises `ValueError` from `get_digits` on the `-`:

```python
num2words(-5, lang='pl')  # ValueError: invalid literal for int() with base 10: '-'
```

cs and sk crash the same way, and negatives in (-1, 0) such as `-0.5` silently lost their sign. The base implementation and the other languages already handle this. Fixed by stripping the leading minus once at the top of `to_cardinal` and prepending `negword`, which covers both integer and decimal negatives.

Closes #362, closes #71. Open PR #646 fixes negative decimals for these languages, but its pl/cs/sk changes only touch the decimal branch, so the integer crash above remains; this handles both at one place.