### PR TITLE
Fix KeyError/IndexError on negative ordinals in Hindi and Arabic

### DIFF
--- a/num2words/lang_AR.py
+++ b/num2words/lang_AR.py
@@ -381,6 +381,7 @@ class Num2Word_AR(Num2Word_Base):
         return self.convert(value=value)
 
     def to_ordinal(self, number, prefix=''):
+        self.verify_ordinal(number)
         if number <= 19:
             return "{}".format(self.arabicOrdinal[number])
         if number < 100:

--- a/num2words/lang_HI.py
+++ b/num2words/lang_HI.py
@@ -192,6 +192,7 @@ class Num2Word_HI(Num2Word_Base):
                            str(value)))
 
     def to_ordinal_num(self, value):
+        self.verify_ordinal(value)
         if value in self._irregular_ordinals_nums:
             return self._irregular_ordinals_nums[value]
 

--- a/tests/test_ar.py
+++ b/tests/test_ar.py
@@ -97,6 +97,15 @@ class Num2WordsARTest(TestCase):
                          lang="ar"), 'ثلاث و عشرون')
         self.assertEqual(num2words(23, lang="ar"), 'ثلاثة و عشرون')
 
+    def test_ordinal_rejects_negative(self):
+        # negatives used to index arabicOrdinal backwards or crash in convert
+        with self.assertRaises(TypeError):
+            num2words(-1, lang='ar', to='ordinal')
+        with self.assertRaises(TypeError):
+            num2words(-100, lang='ar', to='ordinal')
+        with self.assertRaises(TypeError):
+            num2words(-1, lang='ar', to='ordinal_num')
+
     def test_cardinal(self):
         self.assertEqual(num2words(0, to='cardinal', lang='ar'), 'صفر')
         self.assertEqual(num2words(12, to='cardinal', lang='ar'), 'اثنا عشر')

--- a/tests/test_hi.py
+++ b/tests/test_hi.py
@@ -286,6 +286,15 @@ class Num2WordsHITest(TestCase):
                 msg="failing number %s" % number,
             )
 
+    def test_ordinal_num_rejects_negative_and_float(self):
+        # digit-char map; negatives/floats must raise TypeError, not KeyError
+        with self.assertRaises(TypeError):
+            num2words(-1, lang="hi", to="ordinal_num")
+        with self.assertRaises(TypeError):
+            num2words(1.5, lang="hi", to="ordinal_num")
+        # word ordinals still accept negatives
+        self.assertEqual(num2words(-1, lang="hi", to="ordinal"), "माइनस एकवाँ")
+
     # In python3, Hindi numbers are implicitly converted into number
     # as `assert int('४२') == 42`.
     # Thus it's possible to pass Hindi numbers string directly


### PR DESCRIPTION
Arabic to_ordinal indexes arabicOrdinal with negatives, and Hindi to_ordinal_num KeyErrors on negatives/floats. Call verify_ordinal so both raise TypeError like other languages.