### PR TITLE
fix: handle negative Vietnamese cardinals without corrupting words

### DIFF
--- a/num2words/lang_VI.py
+++ b/num2words/lang_VI.py
@@ -85,6 +85,11 @@ class Num2Word_VI(object):
                 return ret
 
     def number_to_text(self, number):
+        # Negatives must not index to_19 from the end (e.g. -1 -> "mười chín").
+        minus = u''
+        if number < 0:
+            minus = u'âm '
+            number = abs(number)
         number = '%.2f' % number
         the_list = str(number).split('.')
         start_word = self.vietnam_number(int(the_list[0]))
@@ -92,7 +97,7 @@ class Num2Word_VI(object):
         if len(the_list) > 1 and int(the_list[1]) > 0:
             end_word = self.vietnam_number(int(the_list[1]))
             final_result = final_result + ' phẩy ' + end_word
-        return final_result
+        return minus + final_result
 
     def to_cardinal(self, number):
         return self.number_to_text(number)

--- a/tests/test_vi.py
+++ b/tests/test_vi.py
@@ -137,3 +137,11 @@ class Num2WordsVITest(TestCase):
             num2words(1000101017, lang="vi"),
             "một tỷ một trăm lẻ một nghìn lẻ mười bảy"
         )
+
+    def test_negative(self):
+        self.assertEqual(num2words(-1, lang="vi"), "âm một")
+        self.assertEqual(num2words(-19, lang="vi"), "âm mười chín")
+        self.assertEqual(num2words(-20, lang="vi"), "âm hai mươi")
+        self.assertEqual(num2words(-100, lang="vi"), "âm một trăm")
+        self.assertEqual(num2words(-1.5, lang="vi"), "âm một phẩy năm mươi")
+


### PR DESCRIPTION
lang_VI.number_to_text hits DataLoss/IndexError when negative int indexes to_19 from end producing wrong words or crash. This PR fixes the regression with a focused test covering the case.
