### PR TITLE
fix: allow Mongolian ordinal zero without IndexError

### DIFF
--- a/num2words/lang_MN.py
+++ b/num2words/lang_MN.py
@@ -240,7 +240,7 @@ class Num2Word_MN(Num2Word_Base):
         if number_str[-1] != '0':
             if number_str[-1] in ('1', '4', '9'):
                 suffix = 'дүгээр'
-        elif number_str[-2] != '0':
+        elif len(number_str) > 1 and number_str[-2] != '0':
             if number_str[-2] in ('4', '9'):
                 suffix = 'дүгээр'
         return suffix

--- a/tests/test_mn.py
+++ b/tests/test_mn.py
@@ -85,6 +85,10 @@ class Num2WordsMNTest(TestCase):
             num2words(1000, lang='mn', to='ordinal'),
             "нэг мянга дугаар"
         )
+        self.assertEqual(
+            num2words(0, lang='mn', to='ordinal'),
+            "тэг дугаар"
+        )
 
     def test_to_ordinal_num(self):
         self.assertEqual(
@@ -95,6 +99,10 @@ class Num2WordsMNTest(TestCase):
         self.assertEqual(
             num2words(489, lang='mn', to='ordinal_num'),
             "489 дүгээр"
+        )
+        self.assertEqual(
+            num2words(0, lang='mn', to='ordinal_num'),
+            "0 дугаар"
         )
 
     def test_to_year(self):


### PR DESCRIPTION
lang_MN._get_ordinal_suffix hits IndexError when ordinal 0: number_str[-2] on single-digit string. This PR fixes the regression with a focused test covering the case.
