### PR TITLE
fix: handle negative Amharic cardinals via negword

### DIFF
--- a/num2words/lang_AM.py
+++ b/num2words/lang_AM.py
@@ -77,6 +77,10 @@ class Num2Word_AM(lang_EU.Num2Word_EU):
             return self.to_cardinal_float(value)
 
         out = ''
+        if value < 0:
+            value = abs(value)
+            out = "%s " % self.negword.strip()
+
         if value >= self.MAXVAL:
             raise OverflowError(self.errmsg_toobig % (value, self.MAXVAL))
 

--- a/tests/test_am.py
+++ b/tests/test_am.py
@@ -92,3 +92,9 @@ class Num2WordsAMTest(TestCase):
                          'አንድ ሺህ ስድሳ ስድስት')
         self.assertEqual(num2words(1865, lang='am', to='year'),
                          'አሥራ ስምንት መቶ ስድሳ አምስት')
+
+    def test_negative_cardinal(self):
+        self.assertEqual(num2words(-5, lang='am'), 'አሉታዊ አምስት')
+        self.assertEqual(num2words(-100, lang='am'), 'አሉታዊ መቶ')
+        self.assertEqual(num2words(-101, lang='am'), 'አሉታዊ አንድ መቶ አንድ')
+


### PR DESCRIPTION
lang_AM.to_cardinal hits TypeError when negative: override skips negword; splitnum returns None. This PR fixes the regression with a focused test covering the case.
